### PR TITLE
Add support for .dart files 

### DIFF
--- a/packages/core/src/__tests__/dart-support.test.ts
+++ b/packages/core/src/__tests__/dart-support.test.ts
@@ -1,6 +1,6 @@
-import { describe, test, expect } from "bun:test";
-import { smartChunk } from "../services/search/smart-chunker.js";
+import { describe, expect, test } from "bun:test";
 import { CodeCompressor } from "../services/compression/code-compressor.js";
+import { smartChunk } from "../services/search/smart-chunker.js";
 
 describe("Dart support", () => {
   test("smart chunker treats .dart files as code", () => {

--- a/packages/core/src/__tests__/dart-support.test.ts
+++ b/packages/core/src/__tests__/dart-support.test.ts
@@ -1,0 +1,38 @@
+import { describe, test, expect } from "bun:test";
+import { smartChunk } from "../services/search/smart-chunker.js";
+import { CodeCompressor } from "../services/compression/code-compressor.js";
+
+describe("Dart support", () => {
+  test("smart chunker treats .dart files as code", () => {
+    const dartCode = `import 'package:flutter/widgets.dart';
+
+class Counter {
+  int value = 0;
+
+  void increment() {
+    value++;
+  }
+}
+`;
+
+    const chunks = smartChunk(dartCode, "lib/counter.dart");
+
+    expect(chunks.length).toBeGreaterThan(0);
+    expect(chunks.every((chunk) => chunk.type === "code_block")).toBe(true);
+  });
+
+  test("code compressor detects dart language", async () => {
+    const compressor = new CodeCompressor();
+    const dartCode = `import 'dart:convert';
+
+class User {
+  final String name;
+  User(this.name);
+}
+`;
+
+    const compressed = await compressor.compress(dartCode);
+
+    expect(compressed.metadata.language).toBe("dart");
+  });
+});

--- a/packages/core/src/services/compression/code-compressor.ts
+++ b/packages/core/src/services/compression/code-compressor.ts
@@ -228,7 +228,8 @@ export class CodeCompressor implements ICompressor {
     return (
       line.includes('function ') ||
       line.includes('=>') ||
-      /^(public|private|protected|async)?\s*\w+\s*\(/.test(line)
+      /^(public|private|protected|async)?\s*\w+\s*\(/.test(line) ||
+      /^(static\s+)?(?:Future(?:<[^>]+>)?|void|int|double|String|bool|dynamic|num|[A-Z]\w*(?:<[^>]+>)?)\s+\w+\s*\(/.test(line)
     );
   }
 
@@ -315,6 +316,13 @@ export class CodeCompressor implements ICompressor {
    * Detect programming language from content
    */
   private detectLanguage(content: string): string {
+    if (
+      /(\bimport\s+['"][^'"]+['"]\s*;|\blibrary\s+\w+[\w.]*\s*;|\bpart\s+of\s+\w+[\w.]*\s*;)/.test(content) &&
+      /\b(class|enum|mixin|extension)\s+\w+/.test(content)
+    ) {
+      return 'dart';
+    }
+
     if (content.includes('import ') && content.includes('from ')) {
       if (content.includes(': ') || content.includes('interface ')) {
         return 'typescript';

--- a/packages/core/src/services/compression/code-compressor.ts
+++ b/packages/core/src/services/compression/code-compressor.ts
@@ -316,9 +316,19 @@ export class CodeCompressor implements ICompressor {
    * Detect programming language from content
    */
   private detectLanguage(content: string): string {
+    const hasDartDirective = /(\bimport\s+['"][^'"]+['"]\s*;|\blibrary\s+\w+[\w.]*\s*;|\bpart\s+of\s+\w+[\w.]*\s*;)/.test(
+      content
+    );
+    const hasDartType = /\b(class|enum|mixin|extension)\s+\w+/.test(content);
+    const hasDartMain = /\bvoid\s+main\s*\(/.test(content);
+    const hasPartOfQuoted = /\bpart\s+of\s+['"][^'"]+['"]\s*;/.test(content);
+    const hasDartImport = /\bimport\s+['"](dart:|package:)[^'"]+['"]\s*;/.test(content);
+
     if (
-      /(\bimport\s+['"][^'"]+['"]\s*;|\blibrary\s+\w+[\w.]*\s*;|\bpart\s+of\s+\w+[\w.]*\s*;)/.test(content) &&
-      /\b(class|enum|mixin|extension)\s+\w+/.test(content)
+      (hasDartDirective && hasDartType) ||
+      hasDartMain ||
+      hasPartOfQuoted ||
+      hasDartImport
     ) {
       return 'dart';
     }

--- a/packages/core/src/services/search/contextual-search-rlm.ts
+++ b/packages/core/src/services/search/contextual-search-rlm.ts
@@ -147,6 +147,7 @@ export class ContextualSearchRLM {
       ".js",
       ".tsx",
       ".jsx",
+      ".dart",
       ".py",
     ];
 

--- a/packages/core/src/services/search/index-manager.ts
+++ b/packages/core/src/services/search/index-manager.ts
@@ -291,6 +291,7 @@ export class IndexManager {
         ".js",
         ".tsx",
         ".jsx",
+        ".dart",
         ".py",
       ];
 

--- a/packages/core/src/services/search/smart-chunker.ts
+++ b/packages/core/src/services/search/smart-chunker.ts
@@ -673,6 +673,7 @@ const CODE_EXTENSIONS = new Set([
   ".js",
   ".tsx",
   ".jsx",
+  ".dart",
   ".py",
   ".java",
   ".go",

--- a/packages/shared/src/config/index.ts
+++ b/packages/shared/src/config/index.ts
@@ -169,6 +169,7 @@ export const defaultConfig: ServerConfig = {
       ".js",
       ".tsx",
       ".jsx",
+      ".dart",
       ".py",
       ".java",
       ".go",


### PR DESCRIPTION
When testing this TH0TH on my Flutter project it only indexed a few files, then I looked and identified that .dart files where not on the supported definitions.

With this PR It is allowing the TH0TH to work with dart files, I'll keep testing on my project, but I think this can be a valuable contribution.