### PR TITLE
Update README mcp config example

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,11 +49,14 @@ File: `~/.config/opencode/opencode.json`
 
 ```json
 {
-  "mcpServers": {
+  "mcp": {
     "th0th": {
       "type": "local",
-        "command": ["bunx", "@th0th-ai/mcp-client"],
-      "env": {
+      "command": [
+        "bunx",
+        "@th0th-ai/mcp-client"
+      ],
+      "environment": {
         "TH0TH_API_URL": "http://localhost:3333"
       },
       "enabled": true


### PR DESCRIPTION
Update the README example for ~/.config/opencode/opencode.json: rename "mcpServers" to "mcp", change "env" to "environment", and format the "command" entry as an explicit array for clarity and to match the current config schema.