### PR TITLE
feat: multi-provider embeddings, chunker rewrite, search hooks and project_map

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -80,8 +80,31 @@ SANITIZE_INPUTS=true
 #   - ollama  (local, no API key needed) - DEFAULT
 #   - google  (requires GOOGLE_GENERATIVE_AI_API_KEY)
 #   - mistral (requires MISTRAL_API_KEY)
+#   - vercel  (Vercel AI Gateway — requires AI_GATEWAY_API_KEY)
+#   - litellm (LiteLLM proxy — requires LITELLM_BASE_URL)
+#   - custom  (OpenAI-compatible API — requires CUSTOM_EMBEDDING_BASE_URL)
 # If not set, defaults to Ollama
 #EMBEDDING_PROVIDER=ollama
+
+# === Vercel AI Gateway (Cloud proxy to many providers) ===
+# Uses the native @ai-sdk/gateway provider (endpoint: /v3/ai/embedding-model).
+# Browse models: https://vercel.com/ai-gateway/models?capabilities=embedding
+#
+# Model choice — keep in sync with VERCEL_EMBEDDING_DIMENSIONS and the matching
+# vector_documents_<N>d Postgres table:
+#   openai/text-embedding-3-small    → 1536  (cheapest, multi-provider, reliable)
+#   openai/text-embedding-3-large    → 3072  (strongest general, multi-provider)
+#   voyage/voyage-code-3             → 1024  (SOTA for code, voyage-only)
+#   alibaba/qwen3-embedding-8b       → 4096  (deepinfra-only, uses BQ path)
+#EMBEDDING_PROVIDER=vercel
+#AI_GATEWAY_API_KEY=your_vercel_ai_gateway_api_key_here
+#VERCEL_EMBEDDING_MODEL=openai/text-embedding-3-small
+#VERCEL_EMBEDDING_DIMENSIONS=1536
+
+# VERCEL_AI_GATEWAY_URL only needed to point at a staging/proxy endpoint.
+# Do NOT set it to the /v1 OpenAI-compat URL — the native gateway uses /v3/ai.
+#VERCEL_AI_GATEWAY_URL=
+#VERCEL_EMBEDDING_MAX_CHARS=8000
 
 # === Google Embeddings (Cloud) ===
 #GOOGLE_GENERATIVE_AI_API_KEY=your_google_api_key_here
@@ -98,10 +121,47 @@ OLLAMA_EMBEDDING_DIMENSIONS=1024
 # OLLAMA_EMBEDDING_MODEL=qwen3-embedding
 # OLLAMA_EMBEDDING_DIMENSIONS=4096
 
+# Max characters sent per text to the embedding model.
+# Defaults are model-aware: qwen3-embedding=8000, bge-m3=4000.
+# Only override if the Ollama Modelfile has PARAMETER num_ctx set high enough.
+# qwen3-embedding with num_ctx=32768 can safely go up to ~16000 chars.
+#OLLAMA_EMBEDDING_MAX_CHARS=8000
+#EMBEDDING_MAX_CHARS=
+
+# HNSW index parameters (PostgreSQL vector store only).
+# Higher efConstruction = better recall, slower one-time index build.
+# Defaults in code: m=16, efConstruction=128 (recommended for 4096d qwen3).
+#POSTGRES_HNSW_M=16
+#POSTGRES_HNSW_EF_CONSTRUCTION=128
+#POSTGRES_IVFFLAT_LISTS=100
+
 # === Mistral Embeddings (Cloud) ===
 #MISTRAL_API_KEY=
 # Text embeddings - General purpose (1024 dimensions)
 #MISTRAL_TEXT_EMBEDDING_MODEL=mistral-embed
 # Code embeddings - Optimized for code (1536D default, up to 3072D)
 #MISTRAL_CODE_EMBEDDING_MODEL=codestral-embed
+
+# === LiteLLM Proxy (OpenAI-compatible) ===
+# Proxy local/privado para múltiplos modelos via LiteLLM
+#LITELLM_BASE_URL=https://llm.example.local/v1
+#LITELLM_API_KEY=
+#LITELLM_EMBEDDING_MODEL=embed-v-4-0
+#LITELLM_EMBEDDING_DIMENSIONS=1024
+#LITELLM_EMBEDDING_TIMEOUT=60000
+#LITELLM_EMBEDDING_MAX_CHARS=8000
+#LITELLM_EMBEDDING_RPM=
+#LITELLM_EMBEDDING_BATCH_SIZE=
+
+# === Custom Provider (OpenAI-compatible API) ===
+# Supports any OpenAI-compatible endpoint: LM Studio, LocalAI, vLLM, Together.ai, Groq, etc.
+# Requires CUSTOM_EMBEDDING_BASE_URL at minimum; CUSTOM_API_KEY is optional (sent as "none" if unset)
+#CUSTOM_EMBEDDING_BASE_URL=http://localhost:1234/v1
+#CUSTOM_API_KEY=
+#CUSTOM_EMBEDDING_MODEL=text-embedding-3-small
+#CUSTOM_EMBEDDING_DIMENSIONS=1536
+#CUSTOM_EMBEDDING_TIMEOUT=60000
+#CUSTOM_EMBEDDING_MAX_CHARS=8000
+#CUSTOM_EMBEDDING_RPM=
+#CUSTOM_EMBEDDING_BATCH_SIZE=
 

--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,7 @@ yarn-error.log*
 *.swo
 *~
 .DS_Store
+.claude/
 
 # Testing
 coverage/

--- a/apps/claude-plugin/README.md
+++ b/apps/claude-plugin/README.md
@@ -1,0 +1,44 @@
+# th0th — Claude Code plugin
+
+Slash commands and a specialized subagent that make th0th feel native in Claude Code.
+
+## What you get
+
+Slash commands (installed as `/th0th-*`):
+
+| Command | What it does |
+|---------|--------------|
+| `/th0th-map` | Project map: stats, top central files, symbols by kind, languages, recent indexes |
+| `/th0th-index [projectId]` | Index the cwd (polls status, reports ETA) |
+| `/th0th-find <query>` | Semantic code search |
+| `/th0th-def <symbol>` | Go-to-definition (exact then fuzzy fallback) |
+| `/th0th-graph <symbol>` | Reference graph (who calls / imports / extends) |
+| `/th0th-status` | Workspaces health + search analytics |
+
+Subagent:
+
+- **`th0th-navigator`** — exploration specialist that prefers semantic queries over blind file reads. Protects the parent agent's context during large investigations.
+
+## Install
+
+```bash
+# user scope (~/.claude), default
+apps/claude-plugin/install.sh
+
+# or project scope (./.claude)
+apps/claude-plugin/install.sh --project
+```
+
+Restart Claude Code to pick up the new commands.
+
+## Prerequisites
+
+The th0th MCP server must be registered for Claude Code. See `apps/mcp-client/README.md`.
+
+A quick check after install:
+
+```
+/th0th-status
+```
+
+If nothing shows up, the MCP server probably isn't running — start it with the dev-server command from the th0th repo.

--- a/apps/claude-plugin/agents/th0th-navigator.md
+++ b/apps/claude-plugin/agents/th0th-navigator.md
@@ -1,0 +1,29 @@
+---
+name: th0th-navigator
+description: Code exploration specialist that leverages the th0th semantic index instead of brute-force file reads. Use when the user asks "where is X?", "how does Y work?", "who calls Z?", or for any question about an indexed codebase. Starts every investigation by consulting the th0th index (project map, definitions, references) before falling back to Read/Grep.
+tools: ["mcp__th0th__*", "Read", "Grep", "Glob", "Bash(pwd)"]
+model: sonnet
+---
+
+You are th0th-navigator, a subagent specialized in exploring codebases through the th0th semantic index.
+
+## Core principle
+
+The user's codebase is **already indexed** by th0th. Your first move on any question is to query the index, not to read files blindly. File reads are expensive in context; th0th queries are not.
+
+## Playbook for a typical question
+
+1. Resolve the current project: run `pwd` → match basename against `th0th_list_projects`.
+2. Understand the shape of the problem space:
+   - For "what does this project do?" → `th0th_project_map`
+   - For "where is X defined?" → `th0th_go_to_definition` (exact) or `th0th_search_definitions` (substring)
+   - For "who uses / calls X?" → `th0th_get_references`
+   - For "how does this feature work?" → `th0th_search` with a semantic query, then `Read` only the top 2-3 files
+3. Only `Read` files when you already know which 1-3 files matter. Never scan directories exhaustively.
+4. If th0th returns 0 results for a vector search, check if the project is in an orphaned-dims state (other dim tables have chunks for it). If so, tell the parent agent to run `/index` with `forceReindex=true`.
+
+## What you return
+
+A **compact, cited answer** to the parent's question. Each claim must reference a file path + line range. Do not paste long code — summarize and cite.
+
+Your output will be the sole result seen by the parent agent, so make it self-contained.

--- a/apps/claude-plugin/commands/def.md
+++ b/apps/claude-plugin/commands/def.md
@@ -1,0 +1,17 @@
+---
+description: Find symbol definitions (functions, classes, types) in an indexed project
+argument-hint: "<symbolName> [kind]"
+allowed-tools: ["mcp__th0th__th0th_search_definitions", "mcp__th0th__th0th_go_to_definition", "mcp__th0th__th0th_list_projects"]
+---
+
+Find symbol definitions via th0th.
+
+Arguments: `$ARGUMENTS` (first token is symbolName, optional second is a kind filter like `class` or `function`).
+
+Strategy:
+1. If the user gave only a name, call `mcp__th0th__th0th_go_to_definition` first — it's cheaper and usually exact.
+2. If 0 results, fall back to `mcp__th0th__th0th_search_definitions` with `search=<name>` and optional `kind=<kind>`.
+3. Render a table: `name | kind | file:lineStart-lineEnd | exported | centralityScore`.
+4. If the user asked a follow-up like "show me", offer to run `mcp__th0th__th0th_search` for code snippets or `th0th_get_references` for callers.
+
+Resolve projectId from the cwd unless user specifies.

--- a/apps/claude-plugin/commands/find.md
+++ b/apps/claude-plugin/commands/find.md
@@ -1,0 +1,19 @@
+---
+description: Semantic search in an indexed project (th0th)
+argument-hint: "<query>"
+allowed-tools: ["mcp__th0th__th0th_search", "mcp__th0th__th0th_list_projects"]
+---
+
+Run a semantic code search with th0th.
+
+Query: `$ARGUMENTS`
+
+Steps:
+1. Resolve the active project:
+   - Prefer the projectId of the cwd if it's already indexed (call `th0th_list_projects` and match by path basename).
+   - If ambiguous, ask the user.
+2. Call `mcp__th0th__th0th_search` with `query="$ARGUMENTS"`, `projectId=<resolved>`, `limit=10`.
+3. Return a ranked list of hits: `filePath:lineStart-lineEnd — score — label`. For the top 3 results, include 3-5 lines of the matched snippet.
+4. If 0 results, check whether vector store has orphaned chunks (look at previous `/map` output or prompt the user to `/index` with `forceReindex=true`).
+
+Keep the output scannable — no walls of text.

--- a/apps/claude-plugin/commands/graph.md
+++ b/apps/claude-plugin/commands/graph.md
@@ -1,0 +1,16 @@
+---
+description: Show references / call graph for a symbol in an indexed project
+argument-hint: "<symbolName>"
+allowed-tools: ["mcp__th0th__th0th_get_references", "mcp__th0th__th0th_go_to_definition", "mcp__th0th__th0th_list_projects"]
+---
+
+Show the reference graph for `$ARGUMENTS`.
+
+Steps:
+1. Resolve projectId from cwd (`th0th_list_projects` match by path basename).
+2. Call `mcp__th0th__th0th_go_to_definition` with `symbolName=$ARGUMENTS` to locate the definition first.
+3. Call `mcp__th0th__th0th_get_references` with the same `symbolName` (and `fqn` if provided by the definition lookup).
+4. Group the results by file, sorted by reference count descending.
+5. For each file, list `line — ref_kind — context snippet` (keep snippet to 1 line).
+
+If 0 references, the symbol might be defined but unused — note that. If 0 definitions and 0 references, the name might be case-sensitive or a FQN is needed.

--- a/apps/claude-plugin/commands/index.md
+++ b/apps/claude-plugin/commands/index.md
@@ -1,0 +1,19 @@
+---
+description: Index the current working directory with th0th
+argument-hint: "[projectId]"
+allowed-tools: ["mcp__th0th__th0th_index_project", "mcp__th0th__th0th_index_status", "Bash(pwd)"]
+---
+
+Kick off a th0th indexing job for the current directory.
+
+Steps:
+1. Run `pwd` to get the absolute path of the current working directory.
+2. Determine `projectId`:
+   - If the user passed `$1`, use it as projectId.
+   - Otherwise use the basename of the directory (last path segment).
+3. Call `mcp__th0th__th0th_index_project` with `projectPath=<pwd>`, `projectId=<chosen>`, and `forceReindex=true` only if the user explicitly asked to force.
+4. Get the `jobId` back and poll `mcp__th0th__th0th_index_status` with that jobId every ~10 seconds until status is `indexed` or `error`.
+5. Report progress succinctly: percentage, ETA, fileProcessed counters when available. Do not spam.
+6. On completion, show a one-line summary: `Indexed <projectId>: <files> files / <chunks> chunks / <duration>`.
+
+Never re-trigger indexing if there's already an in-flight job for the same projectId (check via `th0th_list_projects` first).

--- a/apps/claude-plugin/commands/map.md
+++ b/apps/claude-plugin/commands/map.md
@@ -1,0 +1,24 @@
+---
+description: Show the th0th project map for an indexed workspace
+argument-hint: "[projectId]"
+allowed-tools: ["mcp__th0th__th0th_project_map", "mcp__th0th__th0th_list_projects"]
+---
+
+Show a project map using th0th.
+
+If the user provided `$1` as an argument, use it as the `id` (projectId) for `mcp__th0th__th0th_project_map`.
+
+Otherwise:
+1. Call `mcp__th0th__th0th_list_projects` to see indexed projects.
+2. If exactly one project is indexed, use it automatically.
+3. If multiple, ask the user which one.
+4. If zero, tell the user to run `/index` first.
+
+Then render the result as a compact summary:
+- Total files / chunks / symbols and last indexed time
+- Top 10 central files with their scores
+- Symbols by kind (table)
+- Files by language (inline list)
+- 3 most recent files
+
+Do not dump raw JSON. Format for human reading.

--- a/apps/claude-plugin/commands/status.md
+++ b/apps/claude-plugin/commands/status.md
@@ -1,0 +1,15 @@
+---
+description: Show th0th health and indexed projects status
+allowed-tools: ["mcp__th0th__th0th_list_projects", "mcp__th0th__th0th_analytics"]
+---
+
+Show a health snapshot of the th0th installation.
+
+1. Call `mcp__th0th__th0th_list_projects` with `status=all`.
+2. Call `mcp__th0th__th0th_analytics` with `type=summary`.
+3. Render:
+   - A table of workspaces: projectId | status | filesCount | chunksCount | lastIndexedAt
+   - Totals: searches performed, unique queries, cache hit rate, top queries
+   - Flag anything unusual: a workspace stuck in `indexing`, a workspace in `error`, or cache hit rate below 30%.
+
+Keep it dense — one screen.

--- a/apps/claude-plugin/install.sh
+++ b/apps/claude-plugin/install.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+#
+# th0th Claude Code plugin installer
+#
+# Copies slash commands and the th0th-navigator subagent into the user's
+# Claude Code config directory. Idempotent — safe to re-run.
+#
+# Usage:
+#   apps/claude-plugin/install.sh           # install at user scope (~/.claude)
+#   apps/claude-plugin/install.sh --project # install at project scope (./.claude)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCOPE="user"
+
+for arg in "$@"; do
+  case "$arg" in
+    --project) SCOPE="project" ;;
+    --user) SCOPE="user" ;;
+    -h|--help)
+      echo "Usage: $0 [--user|--project]"
+      exit 0
+      ;;
+  esac
+done
+
+# Banner
+source "$SCRIPT_DIR/../../scripts/banner.sh"
+th0th_banner
+
+if [[ "$SCOPE" == "project" ]]; then
+  TARGET="$(pwd)/.claude"
+else
+  TARGET="$HOME/.claude"
+fi
+
+echo "Installing th0th Claude Code plugin to: $TARGET"
+mkdir -p "$TARGET/commands" "$TARGET/agents"
+
+# Slash commands — prefix with 'th0th-' to avoid collisions with user commands
+for src in "$SCRIPT_DIR/commands/"*.md; do
+  name="$(basename "$src" .md)"
+  dest="$TARGET/commands/th0th-${name}.md"
+  cp "$src" "$dest"
+  echo "  + /th0th-${name}"
+done
+
+# Subagent — keep original name
+cp "$SCRIPT_DIR/agents/th0th-navigator.md" "$TARGET/agents/th0th-navigator.md"
+echo "  + agent: th0th-navigator"
+
+echo ""
+echo "Done. Restart Claude Code to pick up the new commands."
+echo ""
+echo "Next steps:"
+echo "  1. Make sure the th0th MCP server is registered (see apps/mcp-client/README.md)."
+echo "  2. Try: /th0th-status"
+echo "  3. Try: /th0th-map (on an indexed project)"

--- a/apps/claude-plugin/settings.json.template
+++ b/apps/claude-plugin/settings.json.template
@@ -1,0 +1,28 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-settings.json",
+  "_description": "th0th plugin settings template. Merge into your user or project settings.json.",
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "th0th-session-hint"
+          }
+        ]
+      }
+    ]
+  },
+  "permissions": {
+    "allow": [
+      "mcp__th0th__th0th_list_projects",
+      "mcp__th0th__th0th_project_map",
+      "mcp__th0th__th0th_index_status",
+      "mcp__th0th__th0th_analytics",
+      "mcp__th0th__th0th_search",
+      "mcp__th0th__th0th_search_definitions",
+      "mcp__th0th__th0th_go_to_definition",
+      "mcp__th0th__th0th_get_references"
+    ]
+  }
+}

--- a/apps/mcp-client/package.json
+++ b/apps/mcp-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@th0th-ai/mcp-client",
-  "version": "1.0.3",
+  "version": "1.1.2",
   "description": "th0th MCP server - Semantic code search, memory, and context compression via Model Context Protocol",
   "author": "S1LV4",
   "type": "module",

--- a/apps/mcp-client/src/tool-definitions.ts
+++ b/apps/mcp-client/src/tool-definitions.ts
@@ -356,6 +356,34 @@ export const TOOL_DEFINITIONS: ToolDefinition[] = [
   },
 
   {
+    name: "th0th_project_map",
+    description:
+      "Aggregate view of an indexed project: overall stats (files/chunks/symbols/status/lastIndexedAt), top central files by PageRank (the dependency backbone), symbols grouped by kind (function/class/interface/type/etc.), files grouped by extension (language distribution), and the most-recently indexed files. Use this as a one-shot 'what's in this project?' summary.",
+    apiEndpoint: "/api/v1/workspace/:id/map",
+    apiMethod: "GET",
+    inputSchema: {
+      type: "object",
+      properties: {
+        id: {
+          type: "string",
+          description: "The project ID (as registered via th0th_index_project).",
+        },
+        centralityLimit: {
+          type: "number",
+          description: "Max number of top central files to include. Default 20.",
+          default: 20,
+        },
+        recentLimit: {
+          type: "number",
+          description: "Max number of recently indexed files to include. Default 10.",
+          default: 10,
+        },
+      },
+      required: ["id"],
+    },
+  },
+
+  {
     name: "th0th_search_definitions",
     description:
       "Search for symbol definitions (functions, classes, variables, types, interfaces) in an indexed project. Returns name, kind, file location, line numbers, and doc comments.",
@@ -368,7 +396,7 @@ export const TOOL_DEFINITIONS: ToolDefinition[] = [
           type: "string",
           description: "The project ID to search in",
         },
-        query: {
+        search: {
           type: "string",
           description: "Substring search on symbol name (case-insensitive)",
         },

--- a/apps/opencode-plugin/package.json
+++ b/apps/opencode-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@th0th-ai/opencode-plugin",
-  "version": "1.0.3",
+  "version": "1.1.2",
   "description": "th0th plugin for OpenCode - Semantic code search, memory, and context compression",
   "type": "module",
   "main": "dist/index.js",

--- a/apps/tools-api/package.json
+++ b/apps/tools-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@th0th-ai/tools-api",
-  "version": "1.0.3",
+  "version": "1.1.2",
   "author": "S1LV4",
   "description": "th0th REST API server - Semantic code search, memory, and context compression",
   "type": "module",

--- a/apps/tools-api/package.json
+++ b/apps/tools-api/package.json
@@ -12,8 +12,10 @@
     "dist"
   ],
   "scripts": {
-    "dev": "NODE_TLS_REJECT_UNAUTHORIZED=0 bun --watch src/index.ts",
-    "start": "NODE_TLS_REJECT_UNAUTHORIZED=0 bun src/index.ts",
+    "dev": "bun --watch src/index.ts",
+    "dev:insecure": "NODE_TLS_REJECT_UNAUTHORIZED=0 bun --watch src/index.ts",
+    "start": "bun src/index.ts",
+    "start:insecure": "NODE_TLS_REJECT_UNAUTHORIZED=0 bun src/index.ts",
     "build": "bun build src/index.ts --outdir=dist --target=bun --external prisma-adapter-bun-sqlite --external pg --external @prisma/adapter-pg",
     "type-check": "tsc --noEmit"
   },

--- a/apps/tools-api/package.json
+++ b/apps/tools-api/package.json
@@ -12,9 +12,9 @@
     "dist"
   ],
   "scripts": {
-    "dev": "bun --watch src/index.ts",
-    "start": "bun src/index.ts",
-    "build": "bun build src/index.ts --outdir=dist --target=bun",
+    "dev": "NODE_TLS_REJECT_UNAUTHORIZED=0 bun --watch src/index.ts",
+    "start": "NODE_TLS_REJECT_UNAUTHORIZED=0 bun src/index.ts",
+    "build": "bun build src/index.ts --outdir=dist --target=bun --external prisma-adapter-bun-sqlite --external pg --external @prisma/adapter-pg",
     "type-check": "tsc --noEmit"
   },
   "dependencies": {

--- a/apps/tools-api/src/index.ts
+++ b/apps/tools-api/src/index.ts
@@ -25,7 +25,7 @@ import { workspaceRoutes } from "./routes/workspace.js";
 import { fileRoutes } from "./routes/file.js";
 import { authMiddleware } from "./middleware/auth.js";
 import { errorHandler } from "./middleware/error.js";
-import { getHealthChecker } from "@th0th-ai/core";
+import { getHealthChecker, searchSessionHook, coRetrievalHook } from "@th0th-ai/core";
 
 const PORT = process.env.TH0TH_API_PORT || 3333;
 
@@ -76,6 +76,9 @@ const app = new Elysia({ adapter: node() })
     timestamp: new Date().toISOString(),
   }))
   .listen(PORT);
+
+searchSessionHook.register();
+coRetrievalHook.register(); // active only when TH0TH_CO_RETRIEVAL_HOOK=true
 
 console.log(`th0th Tools API running at http://localhost:${PORT}`);
 console.log(`Swagger docs at http://localhost:${PORT}/swagger`);

--- a/apps/tools-api/src/routes/project.ts
+++ b/apps/tools-api/src/routes/project.ts
@@ -6,17 +6,32 @@
  * GET /api/v1/project/index/status/:jobId - Consultar status de indexação
  */
 
-import { Elysia, t } from "elysia";
 import {
-  IndexProjectTool,
   GetIndexStatusTool,
+  IndexProjectTool,
+  getMemoryRepository,
+  getSearchCache,
   getVectorStore,
   workspaceManager,
-  getMemoryRepository,
 } from "@th0th-ai/core";
+import { Elysia, t } from "elysia";
 
-const indexProjectTool = new IndexProjectTool();
-const getIndexStatusTool = new GetIndexStatusTool();
+let indexProjectTool: IndexProjectTool | null = null;
+let indexStatusTool: GetIndexStatusTool | null = null;
+
+function getIndexProjectTool(): IndexProjectTool {
+  if (!indexProjectTool) {
+    indexProjectTool = new IndexProjectTool();
+  }
+  return indexProjectTool;
+}
+
+function getIndexStatusTool(): GetIndexStatusTool {
+  if (!indexStatusTool) {
+    indexStatusTool = new GetIndexStatusTool();
+  }
+  return indexStatusTool;
+}
 
 export const projectRoutes = new Elysia({ prefix: "/api/v1/project" })
   .get(
@@ -51,7 +66,7 @@ export const projectRoutes = new Elysia({ prefix: "/api/v1/project" })
   .post(
     "/index",
     async ({ body }) => {
-      return await indexProjectTool.handle(body);
+      return await getIndexProjectTool().handle(body);
     },
     {
       body: t.Object({
@@ -102,6 +117,10 @@ export const projectRoutes = new Elysia({ prefix: "/api/v1/project" })
         try {
           const vectorStore = await getVectorStore();
           result.vectorsDeleted = await vectorStore.deleteByProject(projectId);
+          // Invalidate the in-process search cache (L1 + L2). Without this,
+          // queries served from L1 keep returning stale chunk metadata
+          // (file/lineStart/lineEnd) until the process restarts.
+          await getSearchCache().invalidateProject(projectId);
         } catch (e) {
           errors.push(`vectors: ${(e as Error).message}`);
         }
@@ -176,7 +195,7 @@ export const projectRoutes = new Elysia({ prefix: "/api/v1/project" })
   .get(
     "/index/status/:jobId",
     async ({ params }) => {
-      return await getIndexStatusTool.handle({ jobId: params.jobId });
+      return await getIndexStatusTool().handle({ jobId: params.jobId });
     },
     {
       params: t.Object({

--- a/apps/tools-api/src/routes/search.ts
+++ b/apps/tools-api/src/routes/search.ts
@@ -5,17 +5,31 @@
  * POST /api/v1/search/code    - Busca semântica de código
  */
 
+import { SearchCodeTool, SearchProjectTool } from "@th0th-ai/core";
 import { Elysia, t } from "elysia";
-import { SearchProjectTool, SearchCodeTool } from "@th0th-ai/core";
 
-const searchProjectTool = new SearchProjectTool();
-const searchCodeTool = new SearchCodeTool();
+let searchProjectTool: SearchProjectTool | null = null;
+let searchCodeTool: SearchCodeTool | null = null;
+
+function getSearchProjectTool(): SearchProjectTool {
+  if (!searchProjectTool) {
+    searchProjectTool = new SearchProjectTool();
+  }
+  return searchProjectTool;
+}
+
+function getSearchCodeTool(): SearchCodeTool {
+  if (!searchCodeTool) {
+    searchCodeTool = new SearchCodeTool();
+  }
+  return searchCodeTool;
+}
 
 export const searchRoutes = new Elysia({ prefix: "/api/v1/search" })
   .post(
     "/project",
     async ({ body }) => {
-      return await searchProjectTool.handle(body);
+      return await getSearchProjectTool().handle(body);
     },
     {
       body: t.Object({
@@ -48,6 +62,7 @@ export const searchRoutes = new Elysia({ prefix: "/api/v1/search" })
           t.Array(t.String(), { description: "Glob patterns to exclude" }),
         ),
         explainScores: t.Optional(t.Boolean({ default: false })),
+        sessionId: t.Optional(t.String({ description: "Session ID for hook scoping" })),
         format: t.Optional(
           t.Union([t.Literal("json"), t.Literal("toon")], {
             default: "toon",
@@ -66,7 +81,7 @@ export const searchRoutes = new Elysia({ prefix: "/api/v1/search" })
   .post(
     "/code",
     async ({ body }) => {
-      return await searchCodeTool.handle(body);
+      return await getSearchCodeTool().handle(body);
     },
     {
       body: t.Object({

--- a/apps/tools-api/src/routes/workspace.ts
+++ b/apps/tools-api/src/routes/workspace.ts
@@ -11,16 +11,23 @@
  * GET    /api/v1/symbol/definition         ← th0th_go_to_definition
  */
 
+import {
+  IndexProjectTool,
+  symbolGraphService,
+  workspaceManager,
+} from "@th0th-ai/core";
 import { Elysia, t } from "elysia";
 import fs from "fs/promises";
 import path from "path";
-import {
-  workspaceManager,
-  symbolGraphService,
-  IndexProjectTool,
-} from "@th0th-ai/core";
 
-const indexProjectTool = new IndexProjectTool();
+let indexProjectTool: IndexProjectTool | null = null;
+
+function getIndexProjectTool(): IndexProjectTool {
+  if (!indexProjectTool) {
+    indexProjectTool = new IndexProjectTool();
+  }
+  return indexProjectTool;
+}
 
 export const workspaceRoutes = new Elysia({ prefix: "/api/v1" })
   // ── Workspace management ──────────────────────────────────────────────────
@@ -104,7 +111,7 @@ export const workspaceRoutes = new Elysia({ prefix: "/api/v1" })
     async ({ params, body }) => {
       try {
         const { projectPath } = body as { projectPath: string };
-        return await indexProjectTool.handle({
+        return await getIndexProjectTool().handle({
           projectId: params.id,
           projectPath,
           forceReindex: true,
@@ -219,6 +226,42 @@ export const workspaceRoutes = new Elysia({ prefix: "/api/v1" })
       detail: {
         tags: ["symbol"],
         summary: "Go to definition of a symbol",
+      },
+    },
+  )
+
+  .get(
+    "/workspace/:id/map",
+    async ({ params, query }) => {
+      try {
+        const projectId = params.id;
+        const centralityLimit = query.centralityLimit
+          ? parseInt(query.centralityLimit as string, 10)
+          : 20;
+        const recentLimit = query.recentLimit
+          ? parseInt(query.recentLimit as string, 10)
+          : 10;
+
+        const map = await symbolGraphService.getProjectMap(projectId, {
+          centralityLimit,
+          recentLimit,
+        });
+
+        if (!map) {
+          return { success: false, error: `Workspace '${projectId}' not found` };
+        }
+
+        return { success: true, data: map };
+      } catch (error) {
+        return { success: false, error: (error as Error).message };
+      }
+    },
+    {
+      detail: {
+        tags: ["workspace"],
+        summary: "Project map — aggregate view of an indexed workspace",
+        description:
+          "Returns stats, top central files (PageRank), symbols grouped by kind, files grouped by extension, and recently indexed files. Query params: centralityLimit (default 20), recentLimit (default 10).",
       },
     },
   )

--- a/benchmarks/needles/README.md
+++ b/benchmarks/needles/README.md
@@ -1,0 +1,113 @@
+# th0th Needles Benchmark
+
+Needle-in-haystack harness for measuring th0th's semantic search recall against
+real codebases.
+
+## Layout
+
+```
+benchmarks/needles/
+├── scorer.ts            # CLI: reads dataset + harness output, writes report
+├── fixtures/            # Per-project needle datasets (versioned)
+│   └── sicad.json       # 12 needles validated against the Sicad codebase
+└── reports/             # Harness outputs and generated reports (gitignored)
+```
+
+## Pipeline
+
+```
+fixtures/<project>.json ──┐
+                          ├─▶ [E] harness                ─▶ reports/<project>-results.json
+                          │   (Claude calls th0th_search per needle)
+                          │                                       │
+                          │                                       ▼
+                          └────────────────────────▶ [T] scorer.ts ─▶ <project>.md + <project>.evaluations.json
+```
+
+- **E (Extract)** — the harness iterates over `fixtures/<project>.json` and,
+  for each needle, calls
+  `mcp__th0th__th0th_search(query, projectId=<project>, maxResults=10)`.
+  Raw responses are accumulated into `reports/<project>-results.json` in the
+  format documented at the top of `scorer.ts`.
+- **T (Transform/Load)** — `scorer.ts` computes `hit@1/3/5/10`, `MRR`, and
+  per-category / per-difficulty breakdowns. A "hit" requires the chunk's
+  `filePath` to match the needle's expected file AND the chunk's
+  `[lineStart, lineEnd]` to intersect the expected range within
+  `lineTolerance` (default 5).
+
+## Adding a new project
+
+1. Put a fixture at `fixtures/<projectId>.json` following the same shape as
+   `sicad.json` (see "Schema" below).
+2. Make sure the project is indexed by th0th (`mcp__th0th__th0th_index` with
+   `projectPath` and `projectId` matching the fixture).
+3. Run the harness (today: a Claude Code session that loops the queries).
+4. Score:
+   ```sh
+   bun benchmarks/needles/scorer.ts \
+     --dataset benchmarks/needles/fixtures/<projectId>.json \
+     --results benchmarks/needles/reports/<projectId>-results.json
+   ```
+   The scorer writes `<projectId>.md` and `<projectId>.evaluations.json`
+   alongside the results file (override with `--out <prefix>`).
+
+## Why needle-in-haystack?
+
+Each fixture is curated to **penalise keyword search** so it actually exercises
+semantic recall. The Sicad fixture covers seven hard categories:
+
+| Category | What it tests |
+|---|---|
+| `domain-concept-without-keyword` | Historical/legal rules expressed only as arithmetic |
+| `cross-language-stack` | Translation chains: enum → string → BACEN code |
+| `business-rule-in-utility` | Business rules disguised as generic validators |
+| `dynamic-property-access` | `obj[key]`, `'foo' in obj`, `as any` — invisible to indexers |
+| `string-literal-config-magic` | Magic numbers that encode case-law thresholds |
+| `portuguese-domain-concept` | Intent only clear via PT-BR comments (13º salário, pro-rata) |
+| `cross-file-event-coupling` | Fire-and-forget promises with no static coupling |
+
+## Schema
+
+`fixtures/<projectId>.json`:
+
+```jsonc
+{
+  "projectId": "sicad",
+  "version": "1.0.0",
+  "description": "...",
+  "scoring": {
+    "topK": 10,
+    "hitAtK": [1, 3, 5, 10],
+    "lineTolerance": 5,
+    "notes": "A hit requires filePath equality AND [lineStart, lineEnd] intersection (with ±lineTolerance on each side)."
+  },
+  "needles": [
+    {
+      "id": "N01-...",
+      "category": "domain-concept-without-keyword",
+      "difficulty": "hard",
+      "query": "...",
+      "expected": { "filePath": "...", "lineStart": 71, "lineEnd": 93 },
+      "rationale": "..."
+    }
+  ]
+}
+```
+
+`reports/<projectId>-results.json`:
+
+```jsonc
+{
+  "projectId": "sicad",
+  "ranAt": "2026-04-20T00:00:00Z",
+  "results": [
+    {
+      "needleId": "N01-...",
+      "query": "...",
+      "hits": [
+        { "filePath": "...", "lineStart": 1, "lineEnd": 17, "score": 0.84 }
+      ]
+    }
+  ]
+}
+```

--- a/benchmarks/needles/fixtures/th0th.json
+++ b/benchmarks/needles/fixtures/th0th.json
@@ -1,0 +1,181 @@
+{
+  "projectId": "th0th",
+  "version": "1.0.0",
+  "description": "Needles validated against the th0th codebase itself (dogfooding). Each needle targets a non-obvious heuristic, magic constant, or scoring rule that pure keyword search would miss. Captured 2026-04-20.",
+  "scoring": {
+    "topK": 10,
+    "hitAtK": [1, 3, 5, 10],
+    "lineTolerance": 5,
+    "notes": "A hit requires the returned chunk's filePath to equal the needle's filePath AND [lineStart, lineEnd] to intersect the expected range (with ±lineTolerance on each side)."
+  },
+  "needles": [
+    {
+      "id": "N01-pagerank-damping",
+      "category": "string-literal-config-magic",
+      "difficulty": "medium",
+      "query": "constante de damping usada no algoritmo iterativo de relevância de arquivos",
+      "expected": {
+        "filePath": "packages/core/src/services/symbol/centrality.ts",
+        "lineStart": 14,
+        "lineEnd": 14
+      },
+      "rationale": "DAMPING=0.85 declarado como constante top-level. Sem `pagerank` no nome, exige conectar 'damping' ao conceito de PageRank."
+    },
+    {
+      "id": "N02-pagerank-iterations",
+      "category": "string-literal-config-magic",
+      "difficulty": "medium",
+      "query": "limite máximo de iterações no cálculo de centralidade",
+      "expected": {
+        "filePath": "packages/core/src/services/symbol/centrality.ts",
+        "lineStart": 15,
+        "lineEnd": 15
+      },
+      "rationale": "ITERATIONS=20 sem ligação textual a centralidade ou PageRank."
+    },
+    {
+      "id": "N03-keyword-boost-code-query",
+      "category": "business-rule-in-utility",
+      "difficulty": "hard",
+      "query": "fator multiplicador aplicado a resultados de keyword search quando a query parece código",
+      "expected": {
+        "filePath": "packages/core/src/services/search/contextual-search-rlm.ts",
+        "lineStart": 720,
+        "lineEnd": 727
+      },
+      "rationale": "isCodeQuery + KEYWORD_BOOST=2.5 hardcoded inline; heurística não é exposta como config."
+    },
+    {
+      "id": "N04-rrf-vector-blend",
+      "category": "domain-concept-without-keyword",
+      "difficulty": "hard",
+      "query": "proporção entre score RRF e similaridade vetorial bruta na composição do score final",
+      "expected": {
+        "filePath": "packages/core/src/services/search/contextual-search-rlm.ts",
+        "lineStart": 793,
+        "lineEnd": 795
+      },
+      "rationale": "70/30 split (rrfNormalized * 0.7 + vectorSimilarity * 0.3) sem constantes nomeadas."
+    },
+    {
+      "id": "N05-centrality-rerank-bonus",
+      "category": "domain-concept-without-keyword",
+      "difficulty": "hard",
+      "query": "bônus aplicado no ranking final para arquivos com alta centralidade no graph",
+      "expected": {
+        "filePath": "packages/core/src/services/search/contextual-search-rlm.ts",
+        "lineStart": 797,
+        "lineEnd": 804
+      },
+      "rationale": "combinedScore * (1 + 0.2 * centralityScore). Multiplicador 0.2 nu, sem constante."
+    },
+    {
+      "id": "N06-minscore-on-raw-vector",
+      "category": "business-rule-in-utility",
+      "difficulty": "hard",
+      "query": "filtro de score mínimo aplicado na similaridade vetorial bruta e não no score normalizado por RRF",
+      "expected": {
+        "filePath": "packages/core/src/services/search/contextual-search-rlm.ts",
+        "lineStart": 620,
+        "lineEnd": 636
+      },
+      "rationale": "Decisão crítica: minScore usa _rrfRawVectorScore quando disponível porque RRF normaliza top=1.0."
+    },
+    {
+      "id": "N07-brace-counter-strip-strings",
+      "category": "business-rule-in-utility",
+      "difficulty": "hard",
+      "query": "lógica que ignora chaves dentro de strings, regex ou comentários ao contar profundidade de bloco",
+      "expected": {
+        "filePath": "packages/core/src/services/search/smart-chunker.ts",
+        "lineStart": 612,
+        "lineEnd": 630
+      },
+      "rationale": "netBraceDelta strip prévio. Crítico para arquivos com regex literais (parsers, validadores) — drift de depth quebra chunking."
+    },
+    {
+      "id": "N08-no-merge-labeled-chunks",
+      "category": "business-rule-in-utility",
+      "difficulty": "medium",
+      "query": "regra que impede que chunks de código com rótulo semântico sejam mesclados com vizinhos pequenos",
+      "expected": {
+        "filePath": "packages/core/src/services/search/smart-chunker.ts",
+        "lineStart": 678,
+        "lineEnd": 690
+      },
+      "rationale": "Métodos curtos (3-4L getter/setter) têm label = não devem ser absorvidos pelo merge anti-fragmentação."
+    },
+    {
+      "id": "N09-markdown-no-headings-fallback",
+      "category": "business-rule-in-utility",
+      "difficulty": "medium",
+      "query": "fallback que usa chunking fixo quando arquivo markdown não tem nenhum heading",
+      "expected": {
+        "filePath": "packages/core/src/services/search/smart-chunker.ts",
+        "lineStart": 166,
+        "lineEnd": 175
+      },
+      "rationale": "Sem essa regra, README sem ## vira 1 mega-chunk que matcha qualquer query (bias .md descoberto no benchmark Sicad)."
+    },
+    {
+      "id": "N10-discover-sort-priority",
+      "category": "domain-concept-without-keyword",
+      "difficulty": "medium",
+      "query": "ordem de prioridade dos arquivos durante a fase de discover do ETL",
+      "expected": {
+        "filePath": "packages/core/src/services/etl/stages/discover.ts",
+        "lineStart": 97,
+        "lineEnd": 104
+      },
+      "rationale": "Ordem: centrality desc → mtime desc → path asc. Garante que arquivos importantes são embebidos primeiro (early-stop friendly)."
+    },
+    {
+      "id": "N11-fingerprint-cache-key",
+      "category": "business-rule-in-utility",
+      "difficulty": "medium",
+      "query": "comparação de hash que decide se um arquivo precisa ser reparseado no incremental reindex",
+      "expected": {
+        "filePath": "packages/core/src/services/etl/stages/discover.ts",
+        "lineStart": 142,
+        "lineEnd": 147
+      },
+      "rationale": "needsReparse = stored.content_hash !== contentHash. Skip por SHA-256 é o que torna reindex incremental viável."
+    },
+    {
+      "id": "N12-vector-table-by-dimension",
+      "category": "cross-language-stack",
+      "difficulty": "medium",
+      "query": "roteamento dinâmico para tabela do postgres baseado na dimensão do embedding",
+      "expected": {
+        "filePath": "packages/core/src/data/vector/postgres-vector-store.ts",
+        "lineStart": 60,
+        "lineEnd": 63
+      },
+      "rationale": "getTableName retorna `vector_documents_${dim}d`. Conecta env var → provider config → schema postgres."
+    },
+    {
+      "id": "N13-orphaned-chunks-warning",
+      "category": "cross-file-event-coupling",
+      "difficulty": "hard",
+      "query": "alerta emitido quando troca de modelo de embedding deixa chunks de outro tamanho dimensional órfãos",
+      "expected": {
+        "filePath": "packages/core/src/data/vector/postgres-vector-store.ts",
+        "lineStart": 138,
+        "lineEnd": 175
+      },
+      "rationale": "detectOrphanedChunks varre tabelas vector_documents_*d e avisa se houver dados em dim antiga. Bug silencioso comum."
+    },
+    {
+      "id": "N14-binary-quantization-sign",
+      "category": "string-literal-config-magic",
+      "difficulty": "medium",
+      "query": "regra de conversão de embedding float em bit-string usando o sinal do valor",
+      "expected": {
+        "filePath": "packages/core/src/data/vector/postgres-vector-store.ts",
+        "lineStart": 67,
+        "lineEnd": 74
+      },
+      "rationale": "floatsToBit: x ≥ 0 → '1', senão '0'. Threshold 0 hardcoded; base do binary quantization (≥ 2000d)."
+    }
+  ]
+}

--- a/benchmarks/needles/reports/.gitignore
+++ b/benchmarks/needles/reports/.gitignore
@@ -1,0 +1,3 @@
+*.json
+*.md
+!.gitignore

--- a/benchmarks/needles/scorer.ts
+++ b/benchmarks/needles/scorer.ts
@@ -1,0 +1,287 @@
+#!/usr/bin/env bun
+/**
+ * Needle-in-haystack scorer for th0th semantic search.
+ *
+ * Reads a dataset (needles + expected hits) and a results file (raw search
+ * output from a harness), then writes a Markdown report and an evaluations
+ * JSON.
+ *
+ * Usage:
+ *   bun benchmarks/needles/scorer.ts \
+ *     --dataset benchmarks/needles/fixtures/sicad.json \
+ *     --results benchmarks/needles/reports/sicad-2026-04-20.json \
+ *     --out     benchmarks/needles/reports/sicad-2026-04-20
+ *
+ * Defaults (when run from repo root with no args):
+ *   --dataset = benchmarks/needles/fixtures/<projectId>.json
+ *   --results = benchmarks/needles/reports/<projectId>-results.json
+ *   --out     = benchmarks/needles/reports/<projectId>
+ *
+ * The harness (typically Claude Code calling mcp__th0th__th0th_search) is
+ * responsible for producing the results file in this format:
+ *   {
+ *     "projectId": "sicad",
+ *     "ranAt": "ISO-8601",
+ *     "results": [
+ *       { "needleId": "...", "query": "...", "hits": [{ "filePath": "...", "lineStart": 1, "lineEnd": 17, "score": 0.84 }, ...] }
+ *     ]
+ *   }
+ */
+import { readFileSync, writeFileSync, mkdirSync } from "node:fs";
+import { resolve, dirname } from "node:path";
+
+interface NeedleExpected {
+  filePath: string;
+  lineStart: number;
+  lineEnd: number;
+}
+
+interface Needle {
+  id: string;
+  category: string;
+  difficulty: "easy" | "medium" | "hard";
+  query: string;
+  expected: NeedleExpected;
+  rationale: string;
+}
+
+interface Dataset {
+  projectId: string;
+  version: string;
+  description: string;
+  scoring: { topK: number; hitAtK: number[]; lineTolerance: number; notes: string };
+  needles: Needle[];
+}
+
+interface Hit {
+  filePath: string;
+  lineStart: number;
+  lineEnd: number;
+  score: number;
+}
+
+interface RawResult {
+  needleId: string;
+  query: string;
+  hits: Hit[];
+  latencyMs?: number;
+}
+
+interface ResultsFile {
+  projectId: string;
+  ranAt: string;
+  results: RawResult[];
+}
+
+interface Evaluation {
+  needleId: string;
+  category: string;
+  difficulty: string;
+  query: string;
+  expected: NeedleExpected;
+  rank: number | null;
+  topHit: Hit | null;
+  matchedHit: Hit | null;
+  reciprocalRank: number;
+}
+
+function intersects(a: [number, number], b: [number, number], tol: number): boolean {
+  const aStart = a[0] - tol;
+  const aEnd = a[1] + tol;
+  return !(aEnd < b[0] || aStart > b[1]);
+}
+
+function findRank(needle: Needle, hits: Hit[], tol: number): { rank: number | null; hit: Hit | null } {
+  for (let i = 0; i < hits.length; i++) {
+    const h = hits[i];
+    if (
+      h.filePath === needle.expected.filePath &&
+      intersects([h.lineStart, h.lineEnd], [needle.expected.lineStart, needle.expected.lineEnd], tol)
+    ) {
+      return { rank: i + 1, hit: h };
+    }
+  }
+  return { rank: null, hit: null };
+}
+
+function evaluate(dataset: Dataset, results: ResultsFile): { evaluations: Evaluation[]; summary: any } {
+  const tol = dataset.scoring.lineTolerance;
+  const byId = new Map(results.results.map((r) => [r.needleId, r]));
+
+  const evaluations: Evaluation[] = dataset.needles.map((needle) => {
+    const raw = byId.get(needle.id);
+    const hits = raw?.hits ?? [];
+    const { rank, hit } = findRank(needle, hits, tol);
+    return {
+      needleId: needle.id,
+      category: needle.category,
+      difficulty: needle.difficulty,
+      query: needle.query,
+      expected: needle.expected,
+      rank,
+      topHit: hits[0] ?? null,
+      matchedHit: hit,
+      reciprocalRank: rank ? 1 / rank : 0,
+    };
+  });
+
+  const total = evaluations.length;
+  const hitAtK = Object.fromEntries(
+    dataset.scoring.hitAtK.map((k) => [
+      `hit@${k}`,
+      evaluations.filter((e) => e.rank !== null && e.rank <= k).length / total,
+    ]),
+  );
+  const mrr = evaluations.reduce((s, e) => s + e.reciprocalRank, 0) / total;
+
+  const byCategory: Record<string, { n: number; hits: number; mrr: number }> = {};
+  const byDifficulty: Record<string, { n: number; hits: number; mrr: number }> = {};
+  for (const e of evaluations) {
+    for (const [bucket, key] of [
+      [byCategory, e.category],
+      [byDifficulty, e.difficulty],
+    ] as const) {
+      const k = key as string;
+      bucket[k] ??= { n: 0, hits: 0, mrr: 0 };
+      bucket[k].n += 1;
+      bucket[k].hits += e.rank !== null && e.rank <= 5 ? 1 : 0;
+      bucket[k].mrr += e.reciprocalRank;
+    }
+  }
+  for (const bucket of [byCategory, byDifficulty]) {
+    for (const k of Object.keys(bucket)) {
+      bucket[k].mrr = +(bucket[k].mrr / bucket[k].n).toFixed(3);
+    }
+  }
+
+  return {
+    evaluations,
+    summary: {
+      total,
+      ...hitAtK,
+      mrr: +mrr.toFixed(3),
+      byCategory,
+      byDifficulty,
+    },
+  };
+}
+
+function renderMarkdown(
+  dataset: Dataset,
+  results: ResultsFile,
+  evaluations: Evaluation[],
+  summary: any,
+): string {
+  const lines: string[] = [];
+  lines.push(`# th0th Needles Benchmark Report — ${dataset.projectId}`);
+  lines.push("");
+  lines.push(`- Ran at: \`${results.ranAt}\``);
+  lines.push(`- Dataset version: \`${dataset.version}\``);
+  lines.push(`- Needles: **${summary.total}**`);
+  lines.push("");
+  lines.push("## Global metrics");
+  lines.push("");
+  lines.push("| Metric | Value |");
+  lines.push("|---|---|");
+  for (const k of dataset.scoring.hitAtK) {
+    lines.push(`| hit@${k} | ${(summary[`hit@${k}`] * 100).toFixed(1)}% |`);
+  }
+  lines.push(`| MRR | ${summary.mrr} |`);
+  lines.push("");
+  lines.push("## By category");
+  lines.push("");
+  lines.push("| Category | N | hit@5 | MRR |");
+  lines.push("|---|---:|---:|---:|");
+  for (const [cat, v] of Object.entries<any>(summary.byCategory)) {
+    lines.push(`| ${cat} | ${v.n} | ${((v.hits / v.n) * 100).toFixed(0)}% | ${v.mrr} |`);
+  }
+  lines.push("");
+  lines.push("## By difficulty");
+  lines.push("");
+  lines.push("| Difficulty | N | hit@5 | MRR |");
+  lines.push("|---|---:|---:|---:|");
+  for (const [d, v] of Object.entries<any>(summary.byDifficulty)) {
+    lines.push(`| ${d} | ${v.n} | ${((v.hits / v.n) * 100).toFixed(0)}% | ${v.mrr} |`);
+  }
+  lines.push("");
+  lines.push("## Per-needle breakdown");
+  lines.push("");
+  lines.push("| # | ID | Diff | Rank | Top hit | Expected |");
+  lines.push("|---|---|---|---:|---|---|");
+  evaluations.forEach((e, i) => {
+    const rank = e.rank ?? "—";
+    const top = e.topHit ? `${e.topHit.filePath}:${e.topHit.lineStart}-${e.topHit.lineEnd}` : "—";
+    const exp = `${e.expected.filePath}:${e.expected.lineStart}-${e.expected.lineEnd}`;
+    lines.push(`| ${i + 1} | ${e.needleId} | ${e.difficulty} | ${rank} | \`${top}\` | \`${exp}\` |`);
+  });
+  lines.push("");
+  lines.push("## Misses (rank > 5 or not found)");
+  lines.push("");
+  const misses = evaluations.filter((e) => e.rank === null || e.rank > 5);
+  if (misses.length === 0) {
+    lines.push("_None_ ");
+  } else {
+    for (const m of misses) {
+      lines.push(`### ${m.needleId} (${m.difficulty}, ${m.category})`);
+      lines.push(`- **Query:** ${m.query}`);
+      lines.push(`- **Expected:** \`${m.expected.filePath}:${m.expected.lineStart}-${m.expected.lineEnd}\``);
+      lines.push(
+        `- **Top hit:** ${m.topHit ? `\`${m.topHit.filePath}:${m.topHit.lineStart}-${m.topHit.lineEnd}\` (score ${m.topHit.score.toFixed(3)})` : "no hits"}`,
+      );
+      lines.push("");
+    }
+  }
+  return lines.join("\n");
+}
+
+function parseArgs(argv: string[]): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a.startsWith("--")) {
+      const key = a.slice(2);
+      const val = argv[i + 1];
+      if (val && !val.startsWith("--")) {
+        out[key] = val;
+        i++;
+      } else {
+        out[key] = "true";
+      }
+    }
+  }
+  return out;
+}
+
+function main() {
+  const args = parseArgs(process.argv.slice(2));
+
+  if (!args.dataset || !args.results) {
+    console.error("Usage: scorer.ts --dataset <path> --results <path> [--out <path-prefix>]");
+    console.error("  --dataset   path to needles fixture (e.g. fixtures/sicad.json)");
+    console.error("  --results   path to harness output (e.g. reports/sicad-results.json)");
+    console.error("  --out       output path prefix; writes <prefix>.md and <prefix>.evaluations.json");
+    console.error("              defaults to <results>-without-extension");
+    process.exit(1);
+  }
+
+  const datasetPath = resolve(args.dataset);
+  const resultsPath = resolve(args.results);
+  const outPrefix = resolve(
+    args.out ?? resultsPath.replace(/\.json$/, "").replace(/-results$/, ""),
+  );
+
+  const dataset: Dataset = JSON.parse(readFileSync(datasetPath, "utf8"));
+  const results: ResultsFile = JSON.parse(readFileSync(resultsPath, "utf8"));
+  const { evaluations, summary } = evaluate(dataset, results);
+
+  mkdirSync(dirname(outPrefix), { recursive: true });
+  const reportPath = `${outPrefix}.md`;
+  const evalPath = `${outPrefix}.evaluations.json`;
+  writeFileSync(evalPath, JSON.stringify({ summary, evaluations }, null, 2));
+  writeFileSync(reportPath, renderMarkdown(dataset, results, evaluations, summary));
+  console.log(`Report:      ${reportPath}`);
+  console.log(`Evaluations: ${evalPath}`);
+  console.log(`Summary:`, summary);
+}
+
+if (import.meta.main) main();

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "start:mcp": "bun run --filter @th0th-ai/mcp-client start",
     "type-check": "turbo run type-check",
     "test": "turbo run test",
-    "bench:fixture:sicad": "bun run --filter @th0th-ai/core bench:fixture:sicad",
+    "bench:fixture": "bun run --filter @th0th-ai/core bench:fixture:th0th",
     "bench:beir": "bun run --filter @th0th-ai/core bench:beir",
     "lint": "turbo run lint",
     "clean": "rm -rf node_modules apps/*/node_modules packages/*/node_modules apps/*/dist packages/*/dist",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "th0th",
-  "version": "1.0.3",
+  "version": "1.1.2",
   "private": true,
   "author": "S1LV4",
   "description": "th0th - Ancient knowledge keeper for modern code. Semantic search with 98% token reduction",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@th0th-ai/core",
-  "version": "1.0.3",
+  "version": "1.1.2",
   "author": "S1LV4",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/core/prisma/migrations/20260419193214_hnsw_ef_construction_128/migration.sql
+++ b/packages/core/prisma/migrations/20260419193214_hnsw_ef_construction_128/migration.sql
@@ -1,0 +1,38 @@
+/*
+  Migration: hnsw_ef_construction_128
+
+  Rebuilds the HNSW BQ index on vector_documents_4096d with ef_construction=128
+  (up from 64) — pgvector's recommended value for high-dim embeddings (4096d
+  qwen3-embedding). Build time roughly doubles; runtime search latency is
+  unaffected (controlled by hnsw.ef_search GUC, not ef_construction).
+
+  Only affects 4096d because that is the only dimension whose HNSW index is
+  created via migration. Indexes for 1024d and 3072d are created lazily at
+  runtime by PostgresVectorStore.createVectorIndex() and pick up the new
+  default (128) on next index creation.
+
+  -- Note on CONCURRENTLY --
+  Prisma wraps every migration in a transaction, which blocks CONCURRENTLY.
+  This migration uses plain DROP/CREATE, which briefly locks the table. For
+  production deploys against large tables, run the equivalent CONCURRENTLY
+  statements manually before applying the migration, then mark this migration
+  as already applied:
+
+    -- Run manually against production (outside any transaction):
+    DROP INDEX CONCURRENTLY IF EXISTS "idx_vector_documents_4096d_embedding_bq";
+    CREATE INDEX CONCURRENTLY IF NOT EXISTS "idx_vector_documents_4096d_embedding_bq"
+        ON "vector_documents_4096d"
+        USING hnsw (embedding_bq bit_hamming_ops)
+        WITH (m = 16, ef_construction = 128);
+
+    -- Then tell Prisma to skip re-running it:
+    prisma migrate resolve --applied 20260419193214_hnsw_ef_construction_128
+*/
+
+-- Drop the old BQ HNSW index (ef_construction=64) and recreate with 128
+DROP INDEX IF EXISTS "idx_vector_documents_4096d_embedding_bq";
+
+CREATE INDEX IF NOT EXISTS "idx_vector_documents_4096d_embedding_bq"
+    ON "vector_documents_4096d"
+    USING hnsw (embedding_bq bit_hamming_ops)
+    WITH (m = 16, ef_construction = 128);

--- a/packages/core/prisma/migrations/20260419214959_add_vector_1536/migration.sql
+++ b/packages/core/prisma/migrations/20260419214959_add_vector_1536/migration.sql
@@ -1,0 +1,28 @@
+/*
+  Migration: add_vector_1536
+
+  Adds vector_documents_1536d table for 1536-dimension embedding models.
+  Primary use case: openai/text-embedding-3-small (native 1536 dims, MRL-capable).
+
+  1536 < 2000, so pgvector supports HNSW directly on the vector column with
+  vector_cosine_ops (no binary quantization needed — that path is reserved for
+  dims > 2000 in vector_documents_4096d).
+
+  Idempotent — safe to re-run.
+*/
+
+-- CreateTable
+CREATE TABLE IF NOT EXISTS "vector_documents_1536d" (
+    "id" TEXT NOT NULL,
+    "project_id" TEXT NOT NULL,
+    "content" TEXT NOT NULL,
+    "metadata" JSONB NOT NULL DEFAULT '{}',
+    "embedding" vector(1536),
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT "vector_documents_1536d_pkey" PRIMARY KEY ("id")
+);
+
+-- Project lookup index
+CREATE INDEX IF NOT EXISTS "vector_documents_1536d_project_id_idx"
+    ON "vector_documents_1536d"("project_id");

--- a/packages/core/prisma/schema.prisma
+++ b/packages/core/prisma/schema.prisma
@@ -280,7 +280,7 @@ model EmbeddingCache {
 // CRUD operations can use Prisma for type safety.
 
 // Base template for vector documents - NOT USED DIRECTLY
-// Dynamic tables created per dimension: vector_documents_1024d, vector_documents_3072d
+// Dynamic tables created per dimension: vector_documents_1024d, vector_documents_1536d, vector_documents_3072d
 model VectorDocument1024 {
   id         String                         @id
   projectId  String                         @map("project_id")
@@ -292,6 +292,19 @@ model VectorDocument1024 {
 
   @@index([projectId])
   @@map("vector_documents_1024d")
+}
+
+model VectorDocument1536 {
+  id         String                         @id
+  projectId  String                         @map("project_id")
+  content    String
+  metadata   Json                           @default("{}")
+  embedding  Unsupported("vector(1536)")?
+  createdAt  DateTime                       @default(now()) @map("created_at")
+  updatedAt  DateTime                       @updatedAt @map("updated_at")
+
+  @@index([projectId])
+  @@map("vector_documents_1536d")
 }
 
 model VectorDocument3072 {

--- a/packages/core/src/__tests__/co-retrieval-hook.test.ts
+++ b/packages/core/src/__tests__/co-retrieval-hook.test.ts
@@ -1,0 +1,312 @@
+/**
+ * Unit tests for CoRetrievalHook
+ *
+ * Uses dependency injection (createForTest) instead of mock.module so that
+ * graph-store.test.ts is not contaminated via Bun's shared module registry.
+ *
+ * Covers: registration, edge creation, edge reinforcement, feature flag gating,
+ * peer-not-found skip, resilience to repo/graph failures, unregister.
+ */
+
+import { describe, test, expect, mock, beforeEach, afterEach } from "bun:test";
+
+// ── Mock logger only (shared, no dedicated test file) ────────
+const mockLogger = {
+  info: mock(() => {}),
+  warn: mock(() => {}),
+  error: mock(() => {}),
+  debug: mock(() => {}),
+  metric: mock(() => {}),
+};
+
+mock.module("@th0th-ai/shared", () => {
+  const actual = require("@th0th-ai/shared");
+  return { ...actual, logger: mockLogger };
+});
+
+// ── Import after mocks ────────────────────────────────────────
+import { CoRetrievalHook } from "../services/hooks/co-retrieval-hook.js";
+import { eventBus } from "../services/events/event-bus.js";
+
+// ── Mock graph store (injected, no module contamination) ──────
+
+function makeMockGraphStore() {
+  return {
+    getEdge: mock((_from: string, _to: string, _type: string) => null as any),
+    createEdge: mock((_from: string, _to: string, _type: string, _opts?: any) => ({
+      id: "edge_test",
+      sourceId: _from,
+      targetId: _to,
+      relationType: _type,
+      weight: 0.15,
+    })),
+    incrementEdgeWeight: mock((..._args: any[]) => true),
+  };
+}
+
+function makeMockRepo(peers: Array<{ id: string }> = []) {
+  return {
+    findRecentByTag: mock(async (_tag: string, _opts: any) => peers),
+  };
+}
+
+// ── Helpers ──────────────────────────────────────────────────
+
+function makePayload(overrides: Partial<{
+  memoryId: string;
+  projectId: string;
+  sessionId: string;
+  query: string;
+}> = {}) {
+  return {
+    memoryId: "mem_new_abc",
+    projectId: "th0th",
+    sessionId: "sess-xyz",
+    query: "pagerank damping",
+    ...overrides,
+  };
+}
+
+function sleep(ms: number) {
+  return new Promise((r) => setTimeout(r, ms));
+}
+
+// ── Tests ─────────────────────────────────────────────────────
+
+describe("CoRetrievalHook", () => {
+  let mockGraph: ReturnType<typeof makeMockGraphStore>;
+  let mockRepo: ReturnType<typeof makeMockRepo>;
+  let hook: CoRetrievalHook;
+  const OLD_ENV = process.env.TH0TH_CO_RETRIEVAL_HOOK;
+
+  beforeEach(() => {
+    CoRetrievalHook.reset();
+    mockLogger.warn.mockClear();
+    mockLogger.debug.mockClear();
+
+    process.env.TH0TH_CO_RETRIEVAL_HOOK = "true";
+    mockGraph = makeMockGraphStore();
+    mockRepo = makeMockRepo();
+    hook = CoRetrievalHook.createForTest(mockGraph, mockRepo);
+  });
+
+  afterEach(() => {
+    hook.unregisterHook();
+    CoRetrievalHook.reset();
+    if (OLD_ENV === undefined) {
+      delete process.env.TH0TH_CO_RETRIEVAL_HOOK;
+    } else {
+      process.env.TH0TH_CO_RETRIEVAL_HOOK = OLD_ENV;
+    }
+  });
+
+  // ── Feature flag ─────────────────────────────────────────
+
+  describe("feature flag", () => {
+    test("does nothing when TH0TH_CO_RETRIEVAL_HOOK is not set", async () => {
+      delete process.env.TH0TH_CO_RETRIEVAL_HOOK;
+      hook.register();
+      eventBus.publish("memory:session-stored", makePayload());
+      await sleep(20);
+      expect(mockRepo.findRecentByTag).not.toHaveBeenCalled();
+      expect(mockGraph.createEdge).not.toHaveBeenCalled();
+    });
+
+    test("runs when TH0TH_CO_RETRIEVAL_HOOK=true", async () => {
+      hook.register();
+      eventBus.publish("memory:session-stored", makePayload());
+      await sleep(20);
+      expect(mockRepo.findRecentByTag).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  // ── Registration ──────────────────────────────────────────
+
+  describe("register()", () => {
+    test("subscribes to memory:session-stored events", async () => {
+      hook.register();
+      eventBus.publish("memory:session-stored", makePayload());
+      await sleep(20);
+      expect(mockRepo.findRecentByTag).toHaveBeenCalledTimes(1);
+    });
+
+    test("calling register() twice only subscribes once", async () => {
+      hook.register();
+      hook.register();
+      eventBus.publish("memory:session-stored", makePayload());
+      await sleep(20);
+      expect(mockRepo.findRecentByTag).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  // ── Edge creation ─────────────────────────────────────────
+
+  describe("edge creation", () => {
+    test("creates edge when no existing edge and peer found", async () => {
+      mockRepo = makeMockRepo([{ id: "peer_1" }]);
+      hook = CoRetrievalHook.createForTest(mockGraph, mockRepo);
+      hook.register();
+
+      eventBus.publish("memory:session-stored", makePayload({ memoryId: "mem_new" }));
+      await sleep(20);
+
+      expect(mockGraph.createEdge).toHaveBeenCalledTimes(1);
+      const call = mockGraph.createEdge.mock.calls[0];
+      const [from, to] = ["mem_new", "peer_1"].sort();
+      expect(call[0]).toBe(from);
+      expect(call[1]).toBe(to);
+      expect(call[3].weight).toBe(0.15);
+      expect(call[3].autoExtracted).toBe(true);
+    });
+
+    test("IDs are ordered deterministically (lexicographic min → max)", async () => {
+      mockRepo = makeMockRepo([{ id: "zzz_peer" }]);
+      hook = CoRetrievalHook.createForTest(mockGraph, mockRepo);
+      hook.register();
+
+      eventBus.publish("memory:session-stored", makePayload({ memoryId: "aaa_new" }));
+      await sleep(20);
+
+      const [from, to] = mockGraph.createEdge.mock.calls[0];
+      expect(from < to).toBe(true);
+    });
+
+    test("does nothing when no peers found", async () => {
+      hook.register(); // mockRepo returns [] by default
+      eventBus.publish("memory:session-stored", makePayload());
+      await sleep(20);
+      expect(mockGraph.createEdge).not.toHaveBeenCalled();
+      expect(mockGraph.incrementEdgeWeight).not.toHaveBeenCalled();
+    });
+
+    test("limits pairs to MAX_PEERS (5)", async () => {
+      const peers = Array.from({ length: 8 }, (_, i) => ({ id: `peer_${i}` }));
+      mockRepo = makeMockRepo(peers);
+      hook = CoRetrievalHook.createForTest(mockGraph, mockRepo);
+      hook.register();
+
+      eventBus.publish("memory:session-stored", makePayload());
+      await sleep(20);
+
+      expect(mockGraph.createEdge.mock.calls.length).toBeLessThanOrEqual(5);
+    });
+  });
+
+  // ── Edge reinforcement ────────────────────────────────────
+
+  describe("edge reinforcement", () => {
+    test("increments weight when edge already exists", async () => {
+      mockRepo = makeMockRepo([{ id: "peer_existing" }]);
+      mockGraph.getEdge.mockReturnValueOnce({
+        id: "edge_existing",
+        weight: 0.25,
+        sourceId: "mem_new",
+        targetId: "peer_existing",
+      });
+      hook = CoRetrievalHook.createForTest(mockGraph, mockRepo);
+      hook.register();
+
+      eventBus.publish("memory:session-stored", makePayload({ memoryId: "mem_new" }));
+      await sleep(20);
+
+      expect(mockGraph.incrementEdgeWeight).toHaveBeenCalledTimes(1);
+      expect(mockGraph.createEdge).not.toHaveBeenCalled();
+
+      const [, , , delta, cap] = mockGraph.incrementEdgeWeight.mock.calls[0];
+      expect(delta).toBe(0.1);
+      expect(cap).toBe(0.85);
+    });
+  });
+
+  // ── findRecentByTag query parameters ─────────────────────
+
+  describe("query parameters", () => {
+    test("passes correct tag, sessionId, projectId, excludeId", async () => {
+      hook.register();
+
+      const payload = makePayload({
+        memoryId: "mem_abc",
+        projectId: "myproject",
+        sessionId: "sess-123",
+      });
+      eventBus.publish("memory:session-stored", payload);
+      await sleep(20);
+
+      const call = mockRepo.findRecentByTag.mock.calls[0];
+      expect(call[0]).toBe("auto:search-session");
+      expect(call[1].sessionId).toBe("sess-123");
+      expect(call[1].projectId).toBe("myproject");
+      expect(call[1].excludeId).toBe("mem_abc");
+      expect(call[1].limit).toBe(5);
+    });
+  });
+
+  // ── Repo without findRecentByTag ──────────────────────────
+
+  describe("graceful degradation", () => {
+    test("skips when injected repo lacks findRecentByTag", async () => {
+      const repoWithoutMethod = {} as any;
+      hook = CoRetrievalHook.createForTest(mockGraph, repoWithoutMethod);
+      hook.register();
+
+      eventBus.publish("memory:session-stored", makePayload());
+      await sleep(20);
+
+      expect(mockGraph.createEdge).not.toHaveBeenCalled();
+    });
+  });
+
+  // ── Resilience ────────────────────────────────────────────
+
+  describe("resilience", () => {
+    test("does not throw when findRecentByTag rejects", async () => {
+      mockRepo.findRecentByTag.mockRejectedValueOnce(new Error("DB down"));
+      hook.register();
+
+      expect(() =>
+        eventBus.publish("memory:session-stored", makePayload()),
+      ).not.toThrow();
+      await sleep(20);
+      expect(mockLogger.warn).toHaveBeenCalledTimes(1);
+    });
+
+    test("subsequent events still processed after a repo failure", async () => {
+      mockRepo.findRecentByTag.mockRejectedValueOnce(new Error("transient"));
+      hook.register();
+
+      eventBus.publish("memory:session-stored", makePayload({ memoryId: "a" }));
+      await sleep(10);
+
+      mockRepo.findRecentByTag.mockResolvedValueOnce([{ id: "peer_ok" }]);
+      mockGraph.getEdge.mockReturnValueOnce(null);
+      eventBus.publish("memory:session-stored", makePayload({ memoryId: "b" }));
+      await sleep(10);
+
+      expect(mockRepo.findRecentByTag).toHaveBeenCalledTimes(2);
+      expect(mockGraph.createEdge).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  // ── Unregister ────────────────────────────────────────────
+
+  describe("unregisterHook()", () => {
+    test("stops receiving events after unregister", async () => {
+      hook.register();
+      hook.unregisterHook();
+      eventBus.publish("memory:session-stored", makePayload());
+      await sleep(20);
+      expect(mockRepo.findRecentByTag).not.toHaveBeenCalled();
+    });
+
+    test("can re-register after unregister", async () => {
+      hook.register();
+      hook.unregisterHook();
+      hook.register();
+      mockRepo.findRecentByTag.mockResolvedValueOnce([{ id: "peer_1" }]);
+      mockGraph.getEdge.mockReturnValueOnce(null);
+      eventBus.publish("memory:session-stored", makePayload());
+      await sleep(20);
+      expect(mockRepo.findRecentByTag).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/packages/core/src/__tests__/prisma-client-fallback.test.ts
+++ b/packages/core/src/__tests__/prisma-client-fallback.test.ts
@@ -1,0 +1,157 @@
+/**
+ * Unit tests — getPrismaClient() missing-adapter fallback (Issue #25 fix)
+ *
+ * Before the fix, both catch blocks in getPrismaClient() called
+ * `new PrismaClient()` without an adapter. When the `driverAdapters`
+ * preview feature is enabled in schema.prisma, Prisma rejects this and
+ * throws `PrismaClientInitializationError` — a confusing internal error
+ * with no actionable guidance.
+ *
+ * After the fix, both catch blocks throw a plain `Error` with a clear
+ * message telling the user exactly which package to install.
+ *
+ * ── Mocking strategy ─────────────────────────────────────────────────────
+ * Rather than fighting Bun's workspace-level module-mock cache behaviour
+ * (mock.module() cache keys don't reliably match require() resolution paths
+ * across workspace symlinks), the production code exposes a thin `_adapters`
+ * object whose loader methods are the sole callsites for require().  Tests
+ * override individual loaders to throw, simulating a missing package, and
+ * restore them in afterEach.
+ *
+ * `_resetPrismaForTesting()` clears the module-level singleton so each test
+ * starts with a fresh initialisation path.
+ */
+
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+
+// No @th0th-ai/shared mock needed: the adapter loaders throw before
+// config.get() or logger are ever reached in both SQLite and PostgreSQL paths.
+import {
+  getPrismaClient,
+  _adapters,
+  _resetPrismaForTesting,
+} from "../services/query/prisma-client.js";
+
+// ── Adapter override helpers ───────────────────────────────────────────────
+// Save real loaders so they can be restored after each test.
+const realLoadPg = _adapters.loadPg.bind(_adapters);
+const realLoadPrismaPg = _adapters.loadPrismaPg.bind(_adapters);
+const realLoadPrismaBunSqlite = _adapters.loadPrismaBunSqlite.bind(_adapters);
+
+function failPrismaBunSqlite() {
+  _adapters.loadPrismaBunSqlite = () => {
+    throw new Error("Cannot find module 'prisma-adapter-bun-sqlite'");
+  };
+}
+
+function failPrismaPg() {
+  // Throw at the first pg-related load so we never attempt a real connection.
+  _adapters.loadPg = () => {
+    throw new Error("Cannot find module 'pg'");
+  };
+}
+
+function restoreAdapters() {
+  _adapters.loadPg = realLoadPg;
+  _adapters.loadPrismaPg = realLoadPrismaPg;
+  _adapters.loadPrismaBunSqlite = realLoadPrismaBunSqlite;
+}
+
+// ── Helper ─────────────────────────────────────────────────────────────────
+function captureError(): Error {
+  try {
+    getPrismaClient();
+    return new Error("getPrismaClient() did not throw");
+  } catch (e) {
+    return e as Error;
+  }
+}
+
+// ══════════════════════════════════════════════════════════════════════════
+describe("getPrismaClient() — missing adapter fallback (Issue #25)", () => {
+  const savedDatabaseUrl = process.env.DATABASE_URL;
+
+  afterEach(() => {
+    // Always restore adapters and reset singleton so tests are independent.
+    restoreAdapters();
+    _resetPrismaForTesting();
+
+    if (savedDatabaseUrl !== undefined) {
+      process.env.DATABASE_URL = savedDatabaseUrl;
+    } else {
+      delete process.env.DATABASE_URL;
+    }
+  });
+
+  // ── SQLite mode (DATABASE_URL not set) ────────────────────────────────
+  describe("SQLite mode — prisma-adapter-bun-sqlite missing", () => {
+    beforeEach(() => {
+      failPrismaBunSqlite();
+      delete process.env.DATABASE_URL;
+    });
+
+    test("throws an Error when the adapter cannot be loaded", () => {
+      expect(() => getPrismaClient()).toThrow(Error);
+    });
+
+    test("error message identifies the missing package", () => {
+      const err = captureError();
+      expect(err.message).toContain("prisma-adapter-bun-sqlite");
+    });
+
+    test("error message contains an actionable install command", () => {
+      const err = captureError();
+      expect(err.message).toContain("bun add prisma-adapter-bun-sqlite");
+    });
+
+    test("does not surface a PrismaClientInitializationError", () => {
+      const err = captureError();
+      expect(err.message).not.toContain("PrismaClientInitializationError");
+      expect(err.message).not.toContain("PrismaClientOptions");
+    });
+
+    test("prismaInstance is never set — second call also throws", () => {
+      const err1 = captureError();
+      const err2 = captureError();
+      expect(err1.message).toContain("prisma-adapter-bun-sqlite");
+      expect(err2.message).toContain("prisma-adapter-bun-sqlite");
+    });
+  });
+
+  // ── PostgreSQL mode (DATABASE_URL = postgres://...) ───────────────────
+  describe("PostgreSQL mode — pg / @prisma/adapter-pg missing", () => {
+    beforeEach(() => {
+      failPrismaPg();
+      process.env.DATABASE_URL =
+        "postgresql://th0th:th0th_password@localhost:5432/th0th";
+    });
+
+    test("throws an Error when the adapter cannot be loaded", () => {
+      expect(() => getPrismaClient()).toThrow(Error);
+    });
+
+    test("error message identifies the missing packages", () => {
+      const err = captureError();
+      expect(err.message).toContain("pg");
+      expect(err.message).toContain("@prisma/adapter-pg");
+    });
+
+    test("error message contains an actionable install command", () => {
+      const err = captureError();
+      expect(err.message).toContain("bun add pg @prisma/adapter-pg");
+    });
+
+    test("does not surface a PrismaClientInitializationError", () => {
+      const err = captureError();
+      expect(err.message).not.toContain("PrismaClientInitializationError");
+      expect(err.message).not.toContain("PrismaClientOptions");
+    });
+
+    test("prismaInstance is never set — second call also throws", () => {
+      const err1 = captureError();
+      const err2 = captureError();
+      expect(err1.message).toContain("pg");
+      expect(err2.message).toContain("pg");
+    });
+  });
+});

--- a/packages/core/src/__tests__/relation-extractor.test.ts
+++ b/packages/core/src/__tests__/relation-extractor.test.ts
@@ -47,8 +47,15 @@ mock.module("../data/chromadb/vector-store.js", () => ({
   },
 }));
 
+mock.module("../data/memory/memory-repository-factory.js", () => ({
+  getMemoryRepository: () => ({
+    getById: async (_id: string) => null,
+    findRecentWithEmbeddings: async () => [],
+  }),
+}));
+
 import { RelationExtractor } from "../services/graph/relation-extractor.js";
-import type { MemoryRowWithEmbedding } from "../services/graph/types.js";
+import type { MemoryRow } from "../data/memory/memory-repository.js";
 import { GraphStore } from "../services/graph/graph-store.js";
 import fs from "fs";
 import path from "path";
@@ -59,8 +66,8 @@ describe("RelationExtractor.classifyRelation", () => {
   let graphStore: GraphStore;
 
   function makeMemory(
-    overrides: Partial<MemoryRowWithEmbedding> & { similarity?: number },
-  ): MemoryRowWithEmbedding & { similarity: number } {
+    overrides: Partial<MemoryRow> & { similarity?: number },
+  ): MemoryRow & { similarity: number } {
     return {
       id: "test_id",
       content: "test content",
@@ -69,16 +76,18 @@ describe("RelationExtractor.classifyRelation", () => {
       importance: 0.5,
       tags: "[]",
       embedding: null,
+      metadata: null,
       created_at: Date.now(),
       updated_at: Date.now(),
       access_count: 0,
+      last_accessed: null,
       user_id: null,
       session_id: null,
       project_id: null,
       agent_id: null,
       similarity: 0.7,
       ...overrides,
-    } as MemoryRowWithEmbedding & { similarity: number };
+    } as MemoryRow & { similarity: number };
   }
 
   // Use a temp dir for DB
@@ -93,7 +102,6 @@ describe("RelationExtractor.classifyRelation", () => {
   });
 
   afterAll(() => {
-    extractor.close();
     graphStore.close();
     fs.rmSync(cleanupDir, { recursive: true, force: true });
   });

--- a/packages/core/src/__tests__/search-session-hook.test.ts
+++ b/packages/core/src/__tests__/search-session-hook.test.ts
@@ -1,0 +1,258 @@
+/**
+ * Unit tests for SearchSessionHook
+ *
+ * Covers: registration, memory storage, dedup, empty-result skip,
+ * store-failure resilience, and unregister.
+ */
+
+import { describe, test, expect, mock, beforeEach, afterEach } from "bun:test";
+
+// ── Mock shared (logger + MemoryType/Level) ──────────────────
+const mockLogger = {
+  info: mock(() => {}),
+  warn: mock(() => {}),
+  error: mock(() => {}),
+  debug: mock(() => {}),
+  metric: mock(() => {}),
+};
+
+mock.module("@th0th-ai/shared", () => {
+  const actual = require("@th0th-ai/shared");
+  return {
+    ...actual,
+    logger: mockLogger,
+  };
+});
+
+// ── Mock MemoryController ────────────────────────────────────
+const mockStore = mock(async (_input: unknown) => ({
+  memoryId: "mem_test_123",
+  stored: "local" as const,
+  level: "SESSION" as any,
+  type: "conversation" as any,
+}));
+
+mock.module("../controllers/memory-controller.js", () => ({
+  MemoryController: {
+    getInstance: () => ({ store: mockStore }),
+  },
+}));
+
+// ── Import after mocks ────────────────────────────────────────
+import { SearchSessionHook } from "../services/hooks/search-session-hook.js";
+import { eventBus } from "../services/events/event-bus.js";
+
+// ── Helpers ──────────────────────────────────────────────────
+
+function makePayload(overrides: Partial<Parameters<typeof eventBus.publish>[1] & {}> = {}) {
+  return {
+    query: "damping constant pagerank",
+    projectId: "th0th",
+    sessionId: "sess-abc",
+    results: [
+      { filePath: "packages/core/src/services/symbol/centrality.ts", score: 0.9 },
+      { filePath: "packages/core/src/services/search/contextual-search-rlm.ts", score: 0.75 },
+    ],
+    durationMs: 120,
+    resultCount: 2,
+    ...overrides,
+  } as Parameters<(typeof eventBus)["publish"]>[1] & { resultCount: number };
+}
+
+function sleep(ms: number) {
+  return new Promise((r) => setTimeout(r, ms));
+}
+
+// ── Tests ─────────────────────────────────────────────────────
+
+describe("SearchSessionHook", () => {
+  let hook: SearchSessionHook;
+
+  beforeEach(() => {
+    SearchSessionHook.reset();
+    mockStore.mockClear();
+    mockLogger.warn.mockClear();
+    mockLogger.debug.mockClear();
+    hook = SearchSessionHook.getInstance();
+  });
+
+  afterEach(() => {
+    hook.unregisterHook();
+    SearchSessionHook.reset();
+  });
+
+  // ── Registration ──────────────────────────────────────────
+
+  describe("register()", () => {
+    test("subscribes to search:completed on EventBus", async () => {
+      hook.register();
+      eventBus.publish("search:completed", makePayload());
+      await sleep(10);
+      expect(mockStore).toHaveBeenCalledTimes(1);
+    });
+
+    test("calling register() twice only subscribes once", async () => {
+      hook.register();
+      hook.register();
+      eventBus.publish("search:completed", makePayload());
+      await sleep(10);
+      expect(mockStore).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  // ── Memory storage ────────────────────────────────────────
+
+  describe("handleSearchCompleted", () => {
+    test("stores memory with correct shape", async () => {
+      hook.register();
+      const payload = makePayload();
+      eventBus.publish("search:completed", payload);
+      await sleep(10);
+
+      expect(mockStore).toHaveBeenCalledTimes(1);
+      const call = mockStore.mock.calls[0][0] as any;
+      expect(call.type).toBe("conversation");
+      expect(call.projectId).toBe("th0th");
+      expect(call.sessionId).toBe("sess-abc");
+      expect(call.importance).toBe(0.3);
+      expect(call.tags).toContain("auto:search-session");
+      expect(call.tags).toContain("auto:search");
+    });
+
+    test("content includes projectId, query, and top-3 file paths", async () => {
+      hook.register();
+      const payload = makePayload({
+        results: [
+          { filePath: "a.ts", score: 0.9 },
+          { filePath: "b.ts", score: 0.8 },
+          { filePath: "c.ts", score: 0.7 },
+          { filePath: "d.ts", score: 0.6 }, // 4th should be excluded
+        ],
+        resultCount: 4,
+      });
+      eventBus.publish("search:completed", payload);
+      await sleep(10);
+
+      const content: string = (mockStore.mock.calls[0][0] as any).content;
+      expect(content).toContain("th0th");
+      expect(content).toContain("damping constant pagerank");
+      expect(content).toContain("a.ts");
+      expect(content).toContain("b.ts");
+      expect(content).toContain("c.ts");
+      expect(content).not.toContain("d.ts");
+    });
+
+    test("skips storing when resultCount is 0", async () => {
+      hook.register();
+      eventBus.publish("search:completed", makePayload({ resultCount: 0, results: [] }));
+      await sleep(10);
+      expect(mockStore).not.toHaveBeenCalled();
+    });
+
+    test("works without sessionId (anonymous session)", async () => {
+      hook.register();
+      const payload = makePayload({ sessionId: undefined });
+      eventBus.publish("search:completed", payload);
+      await sleep(10);
+
+      expect(mockStore).toHaveBeenCalledTimes(1);
+      const call = mockStore.mock.calls[0][0] as any;
+      expect(call.sessionId).toBeUndefined();
+    });
+  });
+
+  // ── Dedup ─────────────────────────────────────────────────
+
+  describe("dedup", () => {
+    test("does not store same (session, project, query) twice within TTL", async () => {
+      hook.register();
+      const payload = makePayload();
+      eventBus.publish("search:completed", payload);
+      eventBus.publish("search:completed", payload);
+      await sleep(20);
+      expect(mockStore).toHaveBeenCalledTimes(1);
+    });
+
+    test("stores again for different query", async () => {
+      hook.register();
+      eventBus.publish("search:completed", makePayload({ query: "query A" }));
+      eventBus.publish("search:completed", makePayload({ query: "query B" }));
+      await sleep(20);
+      expect(mockStore).toHaveBeenCalledTimes(2);
+    });
+
+    test("stores again for different projectId", async () => {
+      hook.register();
+      eventBus.publish("search:completed", makePayload({ projectId: "project-A" }));
+      eventBus.publish("search:completed", makePayload({ projectId: "project-B" }));
+      await sleep(20);
+      expect(mockStore).toHaveBeenCalledTimes(2);
+    });
+
+    test("stores again for different sessionId", async () => {
+      hook.register();
+      eventBus.publish("search:completed", makePayload({ sessionId: "sess-1" }));
+      eventBus.publish("search:completed", makePayload({ sessionId: "sess-2" }));
+      await sleep(20);
+      expect(mockStore).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  // ── Resilience ────────────────────────────────────────────
+
+  describe("resilience", () => {
+    test("does not throw when MemoryController.store rejects", async () => {
+      mockStore.mockRejectedValueOnce(new Error("DB unavailable"));
+      hook.register();
+      // Fire event — if it throws, the test would fail
+      expect(() =>
+        eventBus.publish("search:completed", makePayload()),
+      ).not.toThrow();
+      await sleep(20);
+      expect(mockLogger.warn).toHaveBeenCalledTimes(1);
+    });
+
+    test("subsequent events still processed after a store failure", async () => {
+      mockStore.mockRejectedValueOnce(new Error("transient error"));
+      hook.register();
+
+      eventBus.publish("search:completed", makePayload({ query: "query A" }));
+      await sleep(10);
+
+      // Reset mockStore so next call succeeds
+      mockStore.mockResolvedValueOnce({
+        memoryId: "mem_ok",
+        stored: "local",
+        level: "SESSION" as any,
+        type: "conversation" as any,
+      });
+
+      eventBus.publish("search:completed", makePayload({ query: "query B" }));
+      await sleep(10);
+
+      // Both calls attempted — first failed, second succeeded
+      expect(mockStore).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  // ── Unregister ────────────────────────────────────────────
+
+  describe("unregisterHook()", () => {
+    test("stops receiving events after unregister", async () => {
+      hook.register();
+      hook.unregisterHook();
+      eventBus.publish("search:completed", makePayload());
+      await sleep(10);
+      expect(mockStore).not.toHaveBeenCalled();
+    });
+
+    test("can re-register after unregister", async () => {
+      hook.register();
+      hook.unregisterHook();
+      hook.register();
+      eventBus.publish("search:completed", makePayload());
+      await sleep(10);
+      expect(mockStore).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/packages/core/src/__tests__/vector-store-factory.test.ts
+++ b/packages/core/src/__tests__/vector-store-factory.test.ts
@@ -39,12 +39,21 @@ describe("VectorStoreFactory", () => {
   beforeEach(async () => {
     // Reset state between tests
     await resetVectorStore();
-    
-    // Clear relevant env vars
+
+    // Clear all env vars that can trigger Postgres or non-Ollama providers.
+    // DATABASE_URL must also be cleared — the factory falls back to it as the
+    // Postgres connection string, so leaving it set causes PostgresVectorStore
+    // to be selected even when VECTOR_STORE_TYPE / POSTGRES_VECTOR_URL are unset.
     delete process.env.VECTOR_STORE_TYPE;
     delete process.env.POSTGRES_VECTOR_URL;
     delete process.env.POSTGRES_VECTOR_POOL_SIZE;
     delete process.env.POSTGRES_VECTOR_INDEX;
+    delete process.env.DATABASE_URL;
+    // Prevent new embedding providers from trying live endpoints during tests
+    delete process.env.LITELLM_BASE_URL;
+    delete process.env.CUSTOM_EMBEDDING_BASE_URL;
+    delete process.env.AI_GATEWAY_API_KEY;
+    delete process.env.VERCEL_AI_GATEWAY_API_KEY;
   });
 
   afterEach(async () => {
@@ -161,12 +170,22 @@ describe("VectorStoreFactory", () => {
 
 // ── Usage Pattern Tests (for documentation) ──────────────────
 describe("Usage Patterns", () => {
+  const savedEnv = { ...process.env };
+
   beforeEach(async () => {
     await resetVectorStore();
+    delete process.env.DATABASE_URL;
+    delete process.env.VECTOR_STORE_TYPE;
+    delete process.env.POSTGRES_VECTOR_URL;
+    delete process.env.LITELLM_BASE_URL;
+    delete process.env.CUSTOM_EMBEDDING_BASE_URL;
+    delete process.env.AI_GATEWAY_API_KEY;
+    delete process.env.VERCEL_AI_GATEWAY_API_KEY;
   });
 
   afterEach(async () => {
     await resetVectorStore();
+    Object.assign(process.env, savedEnv);
   });
 
   test("recommended test setup pattern", async () => {

--- a/packages/core/src/controllers/search-controller.ts
+++ b/packages/core/src/controllers/search-controller.ts
@@ -8,6 +8,7 @@
 
 import { logger } from "@th0th-ai/shared";
 import { ContextualSearchRLM } from "../services/search/contextual-search-rlm.js";
+import { eventBus } from "../services/events/event-bus.js";
 import { minimatch } from "minimatch";
 
 // ── Types ────────────────────────────────────────────────────
@@ -28,6 +29,7 @@ export interface ProjectSearchInput {
    * Results whose filePath is in this list get score * 1.3.
    */
   boostFiles?: string[];
+  sessionId?: string;
 }
 
 export interface ProjectSearchResult {
@@ -96,6 +98,7 @@ export class SearchController {
       exclude,
       explainScores = false,
       boostFiles,
+      sessionId,
     } = input;
 
     const startTime = Date.now();
@@ -163,6 +166,21 @@ export class SearchController {
       }
 
       return base;
+    });
+
+    // Emit search:completed for hook subscribers (e.g. SearchSessionHook)
+    eventBus.publish("search:completed", {
+      query,
+      projectId,
+      sessionId,
+      results: formattedResults.map((r) => ({
+        filePath: r.filePath,
+        score: r.score,
+        lineStart: r.lineStart,
+        lineEnd: r.lineEnd,
+      })),
+      durationMs: Date.now() - startTime,
+      resultCount: formattedResults.length,
     });
 
     // Generate intelligent recommendations

--- a/packages/core/src/data/memory/memory-repository-pg.ts
+++ b/packages/core/src/data/memory/memory-repository-pg.ts
@@ -274,6 +274,74 @@ export class MemoryRepositoryPg {
   }
 
   /**
+   * Find recent memories that contain a given tag, scoped to session/project,
+   * within a time window. Used by CoRetrievalHook to find co-session memories.
+   */
+  async findRecentByTag(
+    tag: string,
+    opts: {
+      sessionId?: string;
+      projectId?: string;
+      excludeId?: string;
+      sinceMs: number;
+      limit: number;
+    },
+  ): Promise<Array<{ id: string }>> {
+    const since = new Date(opts.sinceMs);
+    const conditions: Prisma.Sql[] = [
+      Prisma.sql`${tag} = ANY(tags)`,
+      Prisma.sql`created_at >= ${since}`,
+    ];
+
+    if (opts.sessionId)  conditions.push(Prisma.sql`session_id = ${opts.sessionId}`);
+    if (opts.projectId)  conditions.push(Prisma.sql`project_id = ${opts.projectId}`);
+    if (opts.excludeId)  conditions.push(Prisma.sql`id != ${opts.excludeId}`);
+
+    const whereClause = Prisma.sql`WHERE ${Prisma.join(conditions, ' AND ')}`;
+
+    const rows = await this.prisma.$queryRaw<Array<{ id: string }>>`
+      SELECT id FROM memories
+      ${whereClause}
+      ORDER BY created_at DESC
+      LIMIT ${opts.limit}
+    `;
+    return rows;
+  }
+
+  /**
+   * Find recent memories that have an embedding, for cosine-similarity
+   * comparisons in RelationExtractor. Scoped to a project when provided.
+   */
+  async findRecentWithEmbeddings(
+    excludeId: string,
+    projectId: string | null,
+    limit: number,
+  ): Promise<MemoryRow[]> {
+    const conditions: Prisma.Sql[] = [
+      Prisma.sql`id != ${excludeId}`,
+      Prisma.sql`embedding IS NOT NULL`,
+    ];
+
+    if (projectId) {
+      conditions.push(Prisma.sql`(project_id = ${projectId} OR project_id IS NULL)`);
+    }
+
+    const whereClause = Prisma.sql`WHERE ${Prisma.join(conditions, ' AND ')}`;
+
+    const rows = await this.prisma.$queryRaw<RawMemory[]>`
+      SELECT id, content, type, level,
+             user_id, session_id, project_id, agent_id,
+             importance, tags, embedding, metadata,
+             created_at, updated_at, access_count, last_accessed
+      FROM memories
+      ${whereClause}
+      ORDER BY created_at DESC
+      LIMIT ${limit}
+    `;
+    return rows.map(r => this.toMemoryRow(r));
+  }
+
+  /**
    * No-op — connection is managed by the singleton PrismaClient.
    */
   async close(): Promise<void> {}

--- a/packages/core/src/data/memory/memory-repository.ts
+++ b/packages/core/src/data/memory/memory-repository.ts
@@ -310,6 +310,17 @@ export class MemoryRepository {
     return this.db.prepare(sql).all(...params) as MemoryRow[];
   }
 
+  getById(id: string): MemoryRow | null {
+    return this.db
+      .prepare(
+        `SELECT id, content, type, level, importance, tags, embedding, metadata,
+                created_at, updated_at, access_count, last_accessed,
+                user_id, session_id, project_id, agent_id
+         FROM memories WHERE id = ?`,
+      )
+      .get(id) as MemoryRow | null;
+  }
+
   /**
    * Delete all memories belonging to a project.
    * Returns the number of rows deleted.

--- a/packages/core/src/data/sqlite/symbol-repository-pg.ts
+++ b/packages/core/src/data/sqlite/symbol-repository-pg.ts
@@ -476,6 +476,65 @@ export class SymbolRepositoryPg {
     }));
   }
 
+  /**
+   * Aggregates used to build a project map in a single round trip:
+   * symbols grouped by kind, files grouped by extension, and the most
+   * recently indexed files (absolute timestamp for the caller to format).
+   */
+  async getProjectMapAggregates(
+    projectId: string,
+    recentLimit: number = 10,
+  ): Promise<{
+    symbolsByKind: Record<string, number>;
+    filesByLanguage: Record<string, number>;
+    recentFiles: Array<{ filePath: string; indexedAt: number | null }>;
+  }> {
+    const p = getPrismaClient();
+
+    const [kindRows, langRows, recentRows] = await Promise.all([
+      p.$queryRaw<{ kind: string; count: bigint }[]>`
+        SELECT kind, COUNT(*)::bigint AS count
+        FROM symbol_definitions
+        WHERE project_id = ${projectId}
+        GROUP BY kind
+        ORDER BY count DESC
+      `,
+      // Postgres-native extension extraction; NULLIF avoids treating files
+      // without a dot as extension "" (they fall under "other").
+      p.$queryRaw<{ ext: string | null; count: bigint }[]>`
+        SELECT LOWER(NULLIF(SUBSTRING(relative_path FROM '\\.([^./\\\\]+)$'), '')) AS ext,
+               COUNT(*)::bigint AS count
+        FROM symbol_files
+        WHERE project_id = ${projectId}
+        GROUP BY ext
+        ORDER BY count DESC
+      `,
+      p.$queryRaw<{ relative_path: string; indexed_at: Date }[]>`
+        SELECT relative_path, indexed_at
+        FROM symbol_files
+        WHERE project_id = ${projectId}
+        ORDER BY indexed_at DESC
+        LIMIT ${recentLimit}
+      `,
+    ]);
+
+    const symbolsByKind: Record<string, number> = {};
+    for (const row of kindRows) symbolsByKind[row.kind] = Number(row.count);
+
+    const filesByLanguage: Record<string, number> = {};
+    for (const row of langRows) {
+      const key = row.ext ?? "other";
+      filesByLanguage[key] = Number(row.count);
+    }
+
+    const recentFiles = recentRows.map((r) => ({
+      filePath: r.relative_path,
+      indexedAt: r.indexed_at ? r.indexed_at.getTime() : null,
+    }));
+
+    return { symbolsByKind, filesByLanguage, recentFiles };
+  }
+
   async getCentrality(projectId: string): Promise<Map<string, number>> {
     const p = getPrismaClient();
     const rows = await p.$queryRaw<{ file_path: string; score: number }[]>`

--- a/packages/core/src/data/sqlite/symbol-repository.ts
+++ b/packages/core/src/data/sqlite/symbol-repository.ts
@@ -525,6 +525,48 @@ export class SymbolRepository {
     return (this.stmts.getWorkspace.get(projectId) as WorkspaceRow) ?? null;
   }
 
+  async getProjectMapAggregates(
+    projectId: string,
+    recentLimit: number = 10,
+  ): Promise<{
+    symbolsByKind: Record<string, number>;
+    filesByLanguage: Record<string, number>;
+    recentFiles: Array<{ filePath: string; indexedAt: number | null }>;
+  }> {
+    const kindRows = this.db
+      .prepare(
+        `SELECT kind, COUNT(*) AS count FROM symbol_definitions WHERE project_id = ? GROUP BY kind ORDER BY count DESC`,
+      )
+      .all(projectId) as Array<{ kind: string; count: number }>;
+
+    const fileRows = this.db
+      .prepare(`SELECT relative_path FROM symbol_files WHERE project_id = ?`)
+      .all(projectId) as Array<{ relative_path: string }>;
+
+    const recentRows = this.db
+      .prepare(
+        `SELECT relative_path, indexed_at FROM symbol_files WHERE project_id = ? ORDER BY indexed_at DESC LIMIT ?`,
+      )
+      .all(projectId, recentLimit) as Array<{ relative_path: string; indexed_at: number | null }>;
+
+    const symbolsByKind: Record<string, number> = {};
+    for (const row of kindRows) symbolsByKind[row.kind] = row.count;
+
+    const filesByLanguage: Record<string, number> = {};
+    for (const row of fileRows) {
+      const dot = row.relative_path.lastIndexOf(".");
+      const ext = dot >= 0 ? row.relative_path.slice(dot + 1).toLowerCase() : "other";
+      filesByLanguage[ext] = (filesByLanguage[ext] ?? 0) + 1;
+    }
+
+    const recentFiles = recentRows.map((r) => ({
+      filePath: r.relative_path,
+      indexedAt: r.indexed_at ?? null,
+    }));
+
+    return { symbolsByKind, filesByLanguage, recentFiles };
+  }
+
   listWorkspaces(): WorkspaceRow[] {
     return this.stmts.listWorkspaces.all() as WorkspaceRow[];
   }

--- a/packages/core/src/data/vector/postgres-vector-store.ts
+++ b/packages/core/src/data/vector/postgres-vector-store.ts
@@ -50,7 +50,8 @@ export class PostgresVectorStore extends BaseVectorStore {
     this.config = {
       poolSize: 10,
       indexType: 'hnsw',
-      indexParams: { m: 16, efConstruction: 64, lists: 100 },
+      // efConstruction=128 is the pgvector-recommended value for high-dim vectors (4096d qwen3).
+      indexParams: { m: 16, efConstruction: 128, lists: 100 },
       ...config,
     };
   }
@@ -110,6 +111,11 @@ export class PostgresVectorStore extends BaseVectorStore {
         });
         await this.createFallbackTable(client, providerDimensions);
       }
+
+      // UX guard: warn if chunks exist in another dim table for some projects but
+      // the current dim table is empty — indicates an embedding-model change
+      // without reindex, which makes all semantic search return 0 results.
+      await this.detectOrphanedChunks(client, providerDimensions);
     } finally {
       client.release();
     }
@@ -126,6 +132,57 @@ export class PostgresVectorStore extends BaseVectorStore {
     });
 
     return pool;
+  }
+
+  /**
+   * Detect chunks indexed under a different dimension than the current provider.
+   *
+   * When the user changes EMBEDDING_PROVIDER or the embedding model, the new
+   * provider's dims may not match existing rows (which are stored in
+   * vector_documents_<oldDim>d). Search then silently hits an empty table for
+   * affected projects. We warn so the user knows a reindex is required.
+   */
+  private async detectOrphanedChunks(client: any, currentDim: number): Promise<void> {
+    try {
+      const { rows: dimTables } = await client.query(
+        `SELECT tablename FROM pg_tables
+         WHERE tablename ~ '^vector_documents_[0-9]+d$'
+           AND tablename <> $1`,
+        [this.tableName],
+      );
+      if (dimTables.length === 0) return;
+
+      // Check if the CURRENT dim table has any rows
+      const { rows: currentRows } = await client.query(
+        `SELECT COUNT(*)::int AS n FROM ${this.tableName}`,
+      );
+      const currentCount = currentRows[0]?.n ?? 0;
+
+      for (const { tablename } of dimTables) {
+        const { rows: projects } = await client.query(
+          `SELECT project_id, COUNT(*)::int AS n
+             FROM ${tablename}
+            WHERE project_id NOT IN (SELECT DISTINCT project_id FROM ${this.tableName})
+            GROUP BY project_id`,
+        );
+        if (projects.length === 0) continue;
+
+        const otherDim = tablename.match(/_([0-9]+)d$/)?.[1];
+        logger.warn(
+          `[vector] Orphaned chunks detected: ${tablename} has data for projects not in ${this.tableName}. ` +
+            `Embedding model likely changed from ${otherDim}d → ${currentDim}d. Reindex required.`,
+          {
+            currentTable: this.tableName,
+            currentCount,
+            orphanedTable: tablename,
+            affectedProjects: projects.map((p: any) => ({ projectId: p.project_id, chunks: p.n })),
+          },
+        );
+      }
+    } catch (err) {
+      // Detection is best-effort; don't fail initialization
+      logger.debug('[vector] Orphaned chunks detection failed', { error: (err as Error).message });
+    }
   }
 
   private async createFallbackTable(client: any, dimensions: number): Promise<void> {
@@ -174,7 +231,7 @@ export class PostgresVectorStore extends BaseVectorStore {
 
     if (this.config.indexType === 'hnsw') {
       const m = this.config.indexParams?.m ?? 16;
-      const efConstruction = this.config.indexParams?.efConstruction ?? 64;
+      const efConstruction = this.config.indexParams?.efConstruction ?? 128;
 
       await pool.query(`
         CREATE INDEX CONCURRENTLY IF NOT EXISTS ${indexName}
@@ -239,7 +296,7 @@ export class PostgresVectorStore extends BaseVectorStore {
     });
 
     const m = this.config.indexParams?.m ?? 16;
-    const efConstruction = this.config.indexParams?.efConstruction ?? 64;
+    const efConstruction = this.config.indexParams?.efConstruction ?? 128;
 
     await pool.query(`
       CREATE INDEX CONCURRENTLY IF NOT EXISTS ${bqIndexName}
@@ -294,18 +351,86 @@ export class PostgresVectorStore extends BaseVectorStore {
     }
   }
 
+  /**
+   * Insert documents, embedding them in sub-batches to avoid overwhelming
+   * the embedding backend. Each sub-batch is its own short transaction
+   * (matches SQLiteVectorStore semantics — partial progress survives an
+   * Ollama crash mid-file, instead of rolling back the whole file).
+   * Fails-open per-document when a whole sub-batch's embed call errors.
+   */
   async addDocuments(documents: VectorDocument[]): Promise<void> {
+    if (documents.length === 0) return;
     const pool = await this.ensureInitialized();
 
-    const contents = documents.map((d) => d.content);
-    const embeddings = await this.embedBatch(contents);
+    // Match SQLiteVectorStore: Ollama bge-m3 crashes on large batches (50+)
+    const EMBED_SUB_BATCH_SIZE = 8;
 
+    let totalInserted = 0;
+    let totalFailed = 0;
+
+    for (let i = 0; i < documents.length; i += EMBED_SUB_BATCH_SIZE) {
+      const subBatch = documents.slice(i, i + EMBED_SUB_BATCH_SIZE);
+
+      let embeddings: number[][] | null = null;
+      try {
+        embeddings = await this.embedBatch(subBatch.map((d) => d.content));
+      } catch (error) {
+        logger.warn('[postgres] Sub-batch embedding failed, falling back per-document', {
+          subBatchIndex: Math.floor(i / EMBED_SUB_BATCH_SIZE),
+          count: subBatch.length,
+          error: (error as Error).message,
+        });
+      }
+
+      if (embeddings) {
+        try {
+          await this.insertSubBatch(pool, subBatch, embeddings);
+          totalInserted += subBatch.length;
+          continue;
+        } catch (error) {
+          logger.warn('[postgres] Sub-batch insert failed, falling back per-document', {
+            subBatchIndex: Math.floor(i / EMBED_SUB_BATCH_SIZE),
+            count: subBatch.length,
+            error: (error as Error).message,
+          });
+        }
+      }
+
+      // Per-document fallback for this sub-batch
+      for (const doc of subBatch) {
+        try {
+          const embedding = await this.embedContent(doc.content);
+          await this.insertSubBatch(pool, [doc], [embedding]);
+          totalInserted++;
+        } catch (singleError) {
+          totalFailed++;
+          logger.warn('[postgres] Skipping document due to embedding/insert error', {
+            id: doc.id,
+            error: (singleError as Error).message,
+          });
+        }
+      }
+    }
+
+    logger.debug('[postgres] Batch documents added to vector store', {
+      inserted: totalInserted,
+      failed: totalFailed,
+      total: documents.length,
+    });
+  }
+
+  /** Insert a pre-embedded sub-batch inside a single short transaction. */
+  private async insertSubBatch(
+    pool: Pool,
+    subBatch: VectorDocument[],
+    embeddings: number[][],
+  ): Promise<void> {
     const client = await pool.connect();
     try {
       await client.query('BEGIN');
 
-      for (let i = 0; i < documents.length; i++) {
-        const doc = documents[i];
+      for (let i = 0; i < subBatch.length; i++) {
+        const doc = subBatch[i];
         const embedding = embeddings[i];
         const projectId = (doc.metadata?.projectId as string) || 'default';
 

--- a/packages/core/src/data/vector/vector-store-factory.ts
+++ b/packages/core/src/data/vector/vector-store-factory.ts
@@ -90,12 +90,22 @@ function getConfigFromEnv(): VectorStoreConfig {
     (!explicitType && postgresUrl?.startsWith('postgresql'));
 
   if (isPostgres && postgresUrl) {
+    const hnswM = Number(process.env.POSTGRES_HNSW_M);
+    const hnswEfConstruction = Number(process.env.POSTGRES_HNSW_EF_CONSTRUCTION);
+    const ivfflatLists = Number(process.env.POSTGRES_IVFFLAT_LISTS);
+
+    const indexParams: { m?: number; efConstruction?: number; lists?: number } = {};
+    if (hnswM) indexParams.m = hnswM;
+    if (hnswEfConstruction) indexParams.efConstruction = hnswEfConstruction;
+    if (ivfflatLists) indexParams.lists = ivfflatLists;
+
     return {
       type: 'postgres',
       postgres: {
         connectionString: postgresUrl,
         poolSize: parseInt(process.env.POSTGRES_VECTOR_POOL_SIZE || '10'),
         indexType: (process.env.POSTGRES_VECTOR_INDEX as 'ivfflat' | 'hnsw') || 'hnsw',
+        ...(Object.keys(indexParams).length > 0 ? { indexParams } : {}),
       },
     };
   }

--- a/packages/core/src/services/embeddings/config.ts
+++ b/packages/core/src/services/embeddings/config.ts
@@ -6,7 +6,7 @@
  */
 
 export interface EmbeddingProviderConfig {
-  provider: "openai" | "google" | "cohere" | "ollama" | "mistral" | string; // Allow custom providers
+  provider: "openai" | "google" | "cohere" | "ollama" | "mistral" | "vercel" | "custom" | "litellm" | string;
   model: string;
   apiKey?: string;
   baseURL?: string; // For Ollama local server
@@ -14,6 +14,7 @@ export interface EmbeddingProviderConfig {
   priority: number; // Lower = higher priority (1 = try first)
   timeout?: number; // milliseconds
   maxRetries?: number;
+  maxChars?: number; // Max characters to send per text (model-specific context limit)
   rateLimits?: {
     requestsPerMinute?: number; // RPM limit
     tokensPerMinute?: number; // TPM limit (approximate)
@@ -61,6 +62,24 @@ function getRateLimits(providerPrefix: string): EmbeddingProviderConfig['rateLim
   };
 }
 
+function getMaxChars(providerPrefix: string, model: string): number {
+  const fromEnv =
+    Number(process.env[`${providerPrefix}_EMBEDDING_MAX_CHARS`]) ||
+    Number(process.env.EMBEDDING_MAX_CHARS);
+  if (fromEnv) return fromEnv;
+
+  const lower = model.toLowerCase();
+  // Strip common namespace prefixes (e.g. "alibaba/qwen3-embedding-8b" → "qwen3-embedding-8b")
+  const bare = lower.includes("/") ? lower.split("/").pop()! : lower;
+  if (bare.startsWith("qwen3-embedding")) return 8000;
+  if (bare.startsWith("bge-m3")) return 4000;
+  if (bare.startsWith("text-embedding-3")) return 8000;
+  if (bare.startsWith("gemini-embedding")) return 8000;
+  if (bare.startsWith("mistral-embed") || bare.startsWith("codestral-embed")) return 8000;
+  if (bare.startsWith("embed-v-4")) return 500000; 
+  return 4000;
+}
+
 /**
  * Provider configurations sorted by priority
  *
@@ -85,49 +104,113 @@ function getRateLimits(providerPrefix: string): EmbeddingProviderConfig['rateLim
 export const embeddingProviders: Record<string, EmbeddingProviderConfig> = {
   // === ENABLED PROVIDERS ===
 
-  google: {
-    provider: "google",
-    model: process.env.GOOGLE_EMBEDDING_MODEL || "gemini-embedding-001",
-    apiKey: process.env.GOOGLE_GENERATIVE_AI_API_KEY || process.env.GOOGLE_API_KEY,
-    dimensions: 3072,
-    priority: process.env.EMBEDDING_PROVIDER === "google" ? 1 : 10,
-    timeout: 60000,
-    maxRetries: 3,
-    rateLimits: getRateLimits("GOOGLE"),
-  },
-  
-  ollama: {
-    provider: "ollama",
-    model: process.env.OLLAMA_EMBEDDING_MODEL || "bge-m3",
-    baseURL: process.env.OLLAMA_BASE_URL || "http://localhost:11434",
-    dimensions: Number(process.env.OLLAMA_EMBEDDING_DIMENSIONS || "1024"),
-    priority: process.env.EMBEDDING_PROVIDER === "ollama" || !process.env.EMBEDDING_PROVIDER ? 1 : 50, // Highest priority by default
-    timeout: 300000, // 5 minutes (local can be slow on first run)
-    maxRetries: 2,
-    rateLimits: getRateLimits("OLLAMA"),
-  },
-  
-  mistralText: {
-    provider: "mistral",
-    model: process.env.MISTRAL_TEXT_EMBEDDING_MODEL || "mistral-embed",
-    apiKey: process.env.MISTRAL_API_KEY,
-    dimensions: 1024,
-    priority: process.env.EMBEDDING_PROVIDER === "mistral" ? 1 : 2, // Fallback to Mistral if Ollama is unavailable
-    timeout: 60000,
-    maxRetries: 3,
-    rateLimits: getRateLimits("MISTRAL"),
-  },
+  google: (() => {
+    const model = process.env.GOOGLE_EMBEDDING_MODEL || "gemini-embedding-001";
+    return {
+      provider: "google",
+      model,
+      apiKey: process.env.GOOGLE_GENERATIVE_AI_API_KEY || process.env.GOOGLE_API_KEY,
+      dimensions: 3072,
+      priority: process.env.EMBEDDING_PROVIDER === "google" ? 1 : 10,
+      timeout: 60000,
+      maxRetries: 3,
+      maxChars: getMaxChars("GOOGLE", model),
+      rateLimits: getRateLimits("GOOGLE"),
+    };
+  })(),
 
-  mistralCode: {
-    provider: "mistral",
-    model: process.env.MISTRAL_CODE_EMBEDDING_MODEL || "codestral-embed",
-    apiKey: process.env.MISTRAL_API_KEY,
-    dimensions: 1536, // Default, can go up to 3072
-    priority: process.env.EMBEDDING_PROVIDER === "mistral" ? 1 : 3,
-    timeout: 60000,
-    maxRetries: 3,
-    rateLimits: getRateLimits("MISTRAL"),
-  },
+  vercel: (() => {
+    const model = process.env.VERCEL_EMBEDDING_MODEL || "alibaba/qwen3-embedding-8b";
+    return {
+      provider: "vercel",
+      model,
+      apiKey: process.env.AI_GATEWAY_API_KEY || process.env.VERCEL_AI_GATEWAY_API_KEY,
+      baseURL: process.env.VERCEL_AI_GATEWAY_URL,
+      dimensions: Number(process.env.VERCEL_EMBEDDING_DIMENSIONS || "4096"),
+      priority: process.env.EMBEDDING_PROVIDER === "vercel" ? 1 : 20,
+      timeout: 60000,
+      maxRetries: 3,
+      maxChars: getMaxChars("VERCEL", model),
+      rateLimits: getRateLimits("VERCEL"),
+    };
+  })(),
+
+  ollama: (() => {
+    const model = process.env.OLLAMA_EMBEDDING_MODEL || "bge-m3";
+    return {
+      provider: "ollama",
+      model,
+      baseURL: process.env.OLLAMA_BASE_URL || "http://localhost:11434",
+      dimensions: Number(process.env.OLLAMA_EMBEDDING_DIMENSIONS || "1024"),
+      priority: process.env.EMBEDDING_PROVIDER === "ollama" || !process.env.EMBEDDING_PROVIDER ? 1 : 50, // Highest priority by default
+      timeout: 300000, // 5 minutes (local can be slow on first run)
+      maxRetries: 2,
+      maxChars: getMaxChars("OLLAMA", model),
+      rateLimits: getRateLimits("OLLAMA"),
+    };
+  })(),
+
+  mistralText: (() => {
+    const model = process.env.MISTRAL_TEXT_EMBEDDING_MODEL || "mistral-embed";
+    return {
+      provider: "mistral",
+      model,
+      apiKey: process.env.MISTRAL_API_KEY,
+      dimensions: 1024,
+      priority: process.env.EMBEDDING_PROVIDER === "mistral" ? 1 : 2, // Fallback to Mistral if Ollama is unavailable
+      timeout: 60000,
+      maxRetries: 3,
+      maxChars: getMaxChars("MISTRAL", model),
+      rateLimits: getRateLimits("MISTRAL"),
+    };
+  })(),
+
+  mistralCode: (() => {
+    const model = process.env.MISTRAL_CODE_EMBEDDING_MODEL || "codestral-embed";
+    return {
+      provider: "mistral",
+      model,
+      apiKey: process.env.MISTRAL_API_KEY,
+      dimensions: 1536, // Default, can go up to 3072
+      priority: process.env.EMBEDDING_PROVIDER === "mistral" ? 1 : 3,
+      timeout: 60000,
+      maxRetries: 3,
+      maxChars: getMaxChars("MISTRAL", model),
+      rateLimits: getRateLimits("MISTRAL"),
+    };
+  })(),
+  litellm: (() => {
+    const model = process.env.LITELLM_EMBEDDING_MODEL || "embed-v-4-0";
+    return {
+      provider: "litellm",
+      model,
+      apiKey: process.env.LITELLM_API_KEY,
+      baseURL: process.env.LITELLM_BASE_URL,
+      dimensions: Number(process.env.LITELLM_EMBEDDING_DIMENSIONS || "1024"),
+      priority: process.env.EMBEDDING_PROVIDER === "litellm" ? 1 : 15,
+      timeout: Number(process.env.LITELLM_EMBEDDING_TIMEOUT || "60000"),
+      maxRetries: 3,
+      maxChars: getMaxChars("LITELLM", model),
+      rateLimits: getRateLimits("LITELLM"),
+    };
+  })(),
+
+  custom: (() => {
+    const model = process.env.CUSTOM_EMBEDDING_MODEL || "text-embedding-3-small";
+    return {
+      provider: "custom",
+      model,
+      apiKey: process.env.CUSTOM_API_KEY,
+      baseURL: process.env.CUSTOM_EMBEDDING_BASE_URL,
+      dimensions: Number(process.env.CUSTOM_EMBEDDING_DIMENSIONS || "1536"),
+      priority: process.env.EMBEDDING_PROVIDER === "custom" ? 1 : 100,
+      timeout: Number(process.env.CUSTOM_EMBEDDING_TIMEOUT || "60000"),
+      maxRetries: 3,
+      maxChars: getMaxChars("CUSTOM", model),
+      rateLimits: getRateLimits("CUSTOM"),
+    };
+  })(),
+
   // === DISABLED PROVIDERS (uncomment and configure to enable) ===
   
   /*
@@ -183,6 +266,21 @@ export function hasApiKey(providerName: string): boolean {
   // Mistral requires API key
   if (config.provider === "mistral") {
     return !!config.apiKey;
+  }
+
+  // Vercel AI Gateway — requires AI_GATEWAY_API_KEY
+  if (config.provider === "vercel") {
+    return !!config.apiKey;
+  }
+
+  // LiteLLM proxy — requires baseURL at minimum (API key optional)
+  if (config.provider === "litellm") {
+    return !!config.baseURL;
+  }
+
+  // Custom OpenAI-compatible provider — requires baseURL at minimum
+  if (config.provider === "custom") {
+    return !!config.baseURL;
   }
 
   // All other providers need API keys

--- a/packages/core/src/services/embeddings/provider.ts
+++ b/packages/core/src/services/embeddings/provider.ts
@@ -12,8 +12,8 @@
  * - Batch operations with token limits
  */
 
-import { embed, embedMany } from "ai";
-import { openai } from "@ai-sdk/openai";
+import { embed, embedMany, gateway, createGateway } from "ai";
+import { openai, createOpenAI } from "@ai-sdk/openai";
 import { google } from "@ai-sdk/google";
 import { cohere } from "@ai-sdk/cohere";
 import { mistral } from "@ai-sdk/mistral";
@@ -143,7 +143,10 @@ export class AISDKEmbeddingProvider implements EmbeddingProvider {
     | "google"
     | "cohere"
     | "ollama"
-    | "mistral";
+    | "mistral"
+    | "vercel"
+    | "custom"
+    | "litellm";
   private readonly apiKey?: string;
   private readonly baseURL?: string;
   private readonly timeout: number;
@@ -161,7 +164,7 @@ export class AISDKEmbeddingProvider implements EmbeddingProvider {
     this.id = providerId;
     this.model = config.model;
     this.dimensions = config.dimensions || 768; // Default to common dimension
-    this.providerType = config.provider as "openai" | "google" | "cohere" | "ollama" | "mistral";
+    this.providerType = config.provider as "openai" | "google" | "cohere" | "ollama" | "mistral" | "vercel" | "custom" | "litellm";
     this.apiKey = config.apiKey;
     this.baseURL = config.baseURL;
     this.timeout = config.timeout || 60000; // Default 60s
@@ -183,25 +186,60 @@ export class AISDKEmbeddingProvider implements EmbeddingProvider {
     }
   }
 
-  /**
-   * Get AI SDK provider instance based on configuration
-   */
-  private getSDKProvider() {
+  private getEmbeddingModel(): any {
     switch (this.providerType) {
-      case "openai":
-        return openai;
+      case "vercel": {
+        const g =
+          this.baseURL || this.apiKey
+            ? createGateway({
+                baseURL: this.baseURL,
+                apiKey: this.apiKey,
+              })
+            : gateway;
+        return g.textEmbeddingModel(this.model);
+      }
+
+      case "litellm": {
+        if (!this.baseURL) {
+          throw new Error("LiteLLM provider requires LITELLM_BASE_URL");
+        }
+        const litellmDimensions = this.dimensions;
+        const litellmFetch = (async (url: Parameters<typeof fetch>[0], init?: Parameters<typeof fetch>[1]) => {
+          if (init?.body && typeof init.body === "string") {
+            const body = JSON.parse(init.body);
+            body.dimensions = litellmDimensions;
+            init = { ...init, body: JSON.stringify(body) };
+          }
+          return fetch(url, init);
+        }) as typeof fetch;
+        return createOpenAI({ baseURL: this.baseURL, apiKey: this.apiKey ?? "none", fetch: litellmFetch }).embedding(this.model);
+      }
+
+      case "custom": {
+        if (!this.baseURL) {
+          throw new Error("Custom provider requires CUSTOM_EMBEDDING_BASE_URL");
+        }
+        return createOpenAI({ baseURL: this.baseURL, apiKey: this.apiKey ?? "none" }).embedding(this.model);
+      }
+
+      case "openai": {
+        const p = this.baseURL
+          ? createOpenAI({ baseURL: this.baseURL, apiKey: this.apiKey })
+          : openai;
+        return p.embedding(this.model);
+      }
 
       case "google":
-        return google;
+        return google.embedding(this.model);
 
       case "cohere":
-        return cohere;
+        return cohere.embedding(this.model);
 
       case "mistral":
-        return mistral;
+        return mistral.embedding(this.model);
 
       case "ollama":
-        return ollama;
+        return ollama.embedding(this.model);
 
       default:
         throw new Error(`Unsupported provider: ${this.providerType}`);
@@ -226,27 +264,22 @@ export class AISDKEmbeddingProvider implements EmbeddingProvider {
   }
 
   /**
-   * Truncate text to fit model context length
+   * Truncate text to fit model context length.
    *
-   * BGE-M3 has an 8192 token context window.
-   * With smart chunking, chunks are much smaller and more semantic,
-   * so we can afford a higher character limit.
-   *
-   * Token estimation: ~4 chars/token for English text, ~2-3 for code.
-   * 4000 chars ≈ 1000-2000 tokens, well within 8192 limit.
+   * Limit is resolved per-provider from config.maxChars (see embeddings/config.ts
+   * getMaxChars). Falls back to 4000 chars (bge-m3 safe default) when not set.
    */
   private truncateText(text: string): string {
-    const MAX_CHARS = 4000; // ~1000-2000 tokens, safe for 8192 token context
-    
+    const MAX_CHARS = this.config.maxChars ?? 4000;
+
     if (text.length <= MAX_CHARS) {
       return text;
     }
-    
-    // Truncate and add marker
+
     const truncated = text.substring(0, MAX_CHARS);
-    logger.warn(
+    logger.debug(
       `[${this.id}] Text truncated to fit context`,
-      { originalLength: text.length, maxChars: MAX_CHARS },
+      { originalLength: text.length, maxChars: MAX_CHARS, model: this.model },
     );
 
     return truncated;
@@ -355,11 +388,8 @@ export class AISDKEmbeddingProvider implements EmbeddingProvider {
               }
 
               // Other providers: Use AI SDK
-              const provider = this.getSDKProvider();
-              const options = this.getProviderOptions();
-
               const { embedding } = await embed({
-                model: provider.embedding(this.model, options) as any,
+                model: this.getEmbeddingModel(),
                 value: text,
               });
 
@@ -557,11 +587,8 @@ export class AISDKEmbeddingProvider implements EmbeddingProvider {
       () =>
         withRetry(
           async () => {
-            const provider = this.getSDKProvider();
-            const options = this.getProviderOptions();
-
             const { embeddings } = await embedMany({
-              model: provider.embedding(this.model, options) as any,
+              model: this.getEmbeddingModel(),
               values: texts,
             });
 

--- a/packages/core/src/services/etl/stages/load.ts
+++ b/packages/core/src/services/etl/stages/load.ts
@@ -30,6 +30,18 @@ export interface LoadResult {
   errors: number;
 }
 
+/** Human-readable duration: "42s", "3m 12s", "1h 04m". */
+function formatDuration(ms: number): string {
+  const totalSec = Math.max(0, Math.round(ms / 1000));
+  if (totalSec < 60) return `${totalSec}s`;
+  const m = Math.floor(totalSec / 60);
+  const s = totalSec % 60;
+  if (m < 60) return `${m}m ${s.toString().padStart(2, "0")}s`;
+  const h = Math.floor(m / 60);
+  const mm = m % 60;
+  return `${h}h ${mm.toString().padStart(2, "0")}m`;
+}
+
 export class LoadStage {
   private vectorStore: Awaited<ReturnType<typeof getVectorStore>> | null = null;
 
@@ -42,18 +54,29 @@ export class LoadStage {
 
   async run(ctx: EtlStageContext, files: ResolvedFile[]): Promise<LoadResult> {
     const t0 = performance.now();
+    const toLoadCount = files.filter((f) => f.file.needsReparse).length;
 
     ctx.emit({
       type: "stage_start",
       stage: "load",
-      payload: { total: files.length, toLoad: files.filter((f) => f.file.needsReparse).length },
+      payload: { total: files.length, toLoad: toLoadCount },
       timestamp: Date.now(),
     });
+
+    if (toLoadCount > 0) {
+      logger.info("ETL Load starting", {
+        projectId: ctx.projectId,
+        filesToLoad: toLoadCount,
+        filesSkipped: files.length - toLoadCount,
+      });
+    }
 
     let filesLoaded = 0;
     let chunksLoaded = 0;
     let symbolsLoaded = 0;
     let errors = 0;
+    let processedSinceStart = 0; // files that actually ran (not skipped) — for ETA rate
+    let lastEtaLogAt = 0;
 
     // Process in batches of 10 to avoid overwhelming the embedding service
     const BATCH = 10;
@@ -86,6 +109,7 @@ export class LoadStage {
             filesLoaded++;
             chunksLoaded += chunkCount;
             symbolsLoaded += symCount;
+            processedSinceStart++;
 
             ctx.emit({
               type: "file_processed",
@@ -100,6 +124,7 @@ export class LoadStage {
             });
           } catch (err) {
             errors++;
+            processedSinceStart++;
             ctx.emit({
               type: "file_error",
               stage: "load",
@@ -114,16 +139,50 @@ export class LoadStage {
         }),
       );
 
+      const current = Math.min(i + BATCH, files.length);
+      const elapsedMs = performance.now() - t0;
+      const remainingToLoad = Math.max(0, toLoadCount - processedSinceStart);
+      // Only compute ETA once we have a real sample and files left to process
+      const filesPerSec = processedSinceStart > 0 && elapsedMs > 0
+        ? (processedSinceStart / elapsedMs) * 1000
+        : 0;
+      const etaMs = filesPerSec > 0 && remainingToLoad > 0
+        ? Math.round(remainingToLoad / filesPerSec * 1000)
+        : 0;
+
       ctx.emit({
         type: "progress",
         stage: "load",
         payload: {
-          current: Math.min(i + BATCH, files.length),
+          current,
           total: files.length,
-          percentage: Math.round((Math.min(i + BATCH, files.length) / files.length) * 100),
+          percentage: Math.round((current / files.length) * 100),
+          processed: processedSinceStart,
+          toLoad: toLoadCount,
+          elapsedMs: Math.round(elapsedMs),
+          filesPerSec: Number(filesPerSec.toFixed(2)),
+          etaMs,
         },
         timestamp: Date.now(),
       });
+
+      // Throttle ETA log to at most every 5s so it stays informative, not spammy
+      if (
+        etaMs > 0 &&
+        processedSinceStart >= BATCH &&
+        elapsedMs - lastEtaLogAt >= 5000
+      ) {
+        lastEtaLogAt = elapsedMs;
+        logger.info("ETL Load progress", {
+          projectId: ctx.projectId,
+          processed: processedSinceStart,
+          toLoad: toLoadCount,
+          percentage: Math.round((processedSinceStart / toLoadCount) * 100),
+          filesPerSec: Number(filesPerSec.toFixed(2)),
+          eta: formatDuration(etaMs),
+          elapsed: formatDuration(elapsedMs),
+        });
+      }
     }
 
     const durationMs = Math.round(performance.now() - t0);
@@ -142,6 +201,10 @@ export class LoadStage {
       symbolsLoaded,
       errors,
       durationMs,
+      duration: formatDuration(durationMs),
+      filesPerSec: filesLoaded > 0 && durationMs > 0
+        ? Number(((filesLoaded / durationMs) * 1000).toFixed(2))
+        : 0,
     });
 
     return { filesLoaded, chunksLoaded, symbolsLoaded, errors };

--- a/packages/core/src/services/etl/stages/parse.ts
+++ b/packages/core/src/services/etl/stages/parse.ts
@@ -25,6 +25,14 @@ import type {
 
 const BATCH_SIZE = 20;
 
+function resolveChunkerMaxChars(): number | undefined {
+  const providerLimit =
+    Number(process.env.OLLAMA_EMBEDDING_MAX_CHARS) ||
+    Number(process.env.EMBEDDING_MAX_CHARS);
+  if (!providerLimit) return undefined;
+  return Math.floor(providerLimit * 0.9);
+}
+
 export class ParseStage {
   async run(ctx: EtlStageContext, files: DiscoveredFile[]): Promise<ParsedFile[]> {
     const t0 = performance.now();
@@ -88,7 +96,12 @@ export class ParseStage {
       const content = await fs.readFile(file.absolutePath, "utf-8");
       const ext = path.extname(file.relativePath).toLowerCase();
 
-      const chunks = smartChunk(content, file.relativePath);
+      const chunkerMaxChars = resolveChunkerMaxChars();
+      const chunks = smartChunk(
+        content,
+        file.relativePath,
+        chunkerMaxChars ? { maxChunkChars: chunkerMaxChars } : {},
+      );
       const symbols = this.extractSymbols(content, ext);
       const rawImports = this.extractImports(content, ext);
 

--- a/packages/core/src/services/etl/stages/parse.ts
+++ b/packages/core/src/services/etl/stages/parse.ts
@@ -26,11 +26,16 @@ import type {
 const BATCH_SIZE = 20;
 
 function resolveChunkerMaxChars(): number | undefined {
-  const providerLimit =
-    Number(process.env.OLLAMA_EMBEDDING_MAX_CHARS) ||
-    Number(process.env.EMBEDDING_MAX_CHARS);
-  if (!providerLimit) return undefined;
-  return Math.floor(providerLimit * 0.9);
+  // Global override takes highest precedence
+  const global = Number(process.env.EMBEDDING_MAX_CHARS);
+  if (Number.isFinite(global) && global > 0) return Math.floor(global * 0.9);
+
+  // Provider-specific override (OLLAMA_, VERCEL_, LITELLM_, CUSTOM_, GOOGLE_, MISTRAL_, …)
+  const provider = (process.env.EMBEDDING_PROVIDER || "ollama").toUpperCase();
+  const providerVal = Number(process.env[`${provider}_EMBEDDING_MAX_CHARS`]);
+  if (Number.isFinite(providerVal) && providerVal > 0) return Math.floor(providerVal * 0.9);
+
+  return undefined; // fall back to DEFAULT_CONFIG.maxChunkChars in smart-chunker
 }
 
 export class ParseStage {

--- a/packages/core/src/services/events/event-bus.ts
+++ b/packages/core/src/services/events/event-bus.ts
@@ -52,6 +52,21 @@ export interface EventMap {
     filesCount?: number;
     symbolsCount?: number;
   };
+  "search:completed": {
+    query: string;
+    projectId: string;
+    sessionId?: string;
+    results: Array<{ filePath: string; score: number; lineStart?: number; lineEnd?: number }>;
+    durationMs: number;
+    resultCount: number;
+  };
+  /** Emitted by SearchSessionHook after a session memory is persisted. */
+  "memory:session-stored": {
+    memoryId: string;
+    projectId?: string;
+    sessionId?: string;
+    query: string;
+  };
 }
 
 export type EventName = keyof EventMap;

--- a/packages/core/src/services/graph/graph-store.ts
+++ b/packages/core/src/services/graph/graph-store.ts
@@ -307,13 +307,34 @@ export class GraphStore {
   }
 
   /**
-   * Update edge weight.
+   * Update edge weight (set).
    */
   updateWeight(edgeId: string, weight: number): boolean {
     const clamped = Math.max(0, Math.min(1, weight));
     const result = this.db
       .prepare("UPDATE memory_edges SET weight = ? WHERE id = ?")
       .run(clamped, edgeId);
+    return (result as any).changes > 0;
+  }
+
+  /**
+   * Atomically increment edge weight by delta, capped at maxWeight.
+   * Safer than read-modify-write for the reinforcement pattern.
+   */
+  incrementEdgeWeight(
+    sourceId: string,
+    targetId: string,
+    relationType: MemoryRelationType,
+    delta: number,
+    maxWeight = 1.0,
+  ): boolean {
+    const result = this.db
+      .prepare(
+        `UPDATE memory_edges
+         SET weight = MIN(weight + ?, ?)
+         WHERE source_id = ? AND target_id = ? AND relation_type = ?`,
+      )
+      .run(delta, maxWeight, sourceId, targetId, relationType);
     return (result as any).changes > 0;
   }
 

--- a/packages/core/src/services/graph/relation-extractor.ts
+++ b/packages/core/src/services/graph/relation-extractor.ts
@@ -10,18 +10,15 @@
  * with optional LLM refinement when available.
  */
 
-import { Database } from "bun:sqlite";
-import path from "path";
 import {
   MemoryRelationType,
-  MemoryType,
   ExtractedRelation,
-  config,
   logger,
 } from "@th0th-ai/shared";
 import { EmbeddingService } from "../../data/chromadb/vector-store.js";
 import { GraphStore } from "./graph-store.js";
-import type { MemoryRowWithEmbedding as MemoryRow } from "./types.js";
+import { getMemoryRepository } from "../../data/memory/memory-repository-factory.js";
+import type { MemoryRow } from "../../data/memory/memory-repository.js";
 
 interface ExtractionOptions {
   /** Max similar memories to compare against */
@@ -100,21 +97,12 @@ const SUPPORT_SIGNALS = [
 ];
 
 export class RelationExtractor {
-  private db!: Database;
   private embeddingService: EmbeddingService;
   private graphStore: GraphStore;
 
   constructor(graphStore?: GraphStore) {
     this.embeddingService = new EmbeddingService();
     this.graphStore = graphStore ?? GraphStore.getInstance();
-    this.initDb();
-  }
-
-  private initDb(): void {
-    const dataDir = config.get("dataDir") as string;
-    const dbPath = path.join(dataDir, "memories.db");
-    this.db = new Database(dbPath);
-    this.db.exec("PRAGMA busy_timeout = 3000");
   }
 
   /**
@@ -136,7 +124,7 @@ export class RelationExtractor {
 
     try {
       // Load the new memory
-      const memory = this.loadMemory(memoryId);
+      const memory = await this.loadMemory(memoryId);
       if (!memory) {
         logger.warn("RelationExtractor: memory not found", { memoryId });
         return 0;
@@ -144,7 +132,11 @@ export class RelationExtractor {
 
       // Get embedding
       const embedding = memory.embedding
-        ? Array.from(new Float32Array(memory.embedding.buffer))
+        ? Array.from(new Float32Array(
+            memory.embedding.buffer,
+            memory.embedding.byteOffset,
+            memory.embedding.byteLength / 4,
+          ))
         : null;
 
       if (!embedding || embedding.every((v) => v === 0)) {
@@ -153,7 +145,7 @@ export class RelationExtractor {
       }
 
       // Find similar memories
-      const candidates = this.findSimilarMemories(
+      const candidates = await this.findSimilarMemories(
         memoryId,
         embedding,
         memory.project_id,
@@ -210,38 +202,17 @@ export class RelationExtractor {
   /**
    * Find memories with similar embeddings (brute-force cosine similarity).
    */
-  private findSimilarMemories(
+  private async findSimilarMemories(
     excludeId: string,
     queryEmbedding: number[],
     projectId: string | null,
     limit: number,
     threshold: number,
-  ): (MemoryRow & { similarity: number })[] {
-    // Fetch candidate memories (recent, same project if possible)
-    const conditions: string[] = ["id != ?"];
-    const params: any[] = [excludeId];
+  ): Promise<(MemoryRow & { similarity: number })[]> {
+    const repo = getMemoryRepository() as any;
+    if (typeof repo.findRecentWithEmbeddings !== "function") return [];
 
-    if (projectId) {
-      conditions.push("(project_id = ? OR project_id IS NULL)");
-      params.push(projectId);
-    }
-
-    conditions.push("embedding IS NOT NULL");
-
-    // Limit scan to recent memories for performance
-    params.push(500);
-
-    const rows = this.db
-      .prepare(
-        `
-      SELECT id, content, type, level, importance, tags, embedding, created_at, project_id
-      FROM memories
-      WHERE ${conditions.join(" AND ")}
-      ORDER BY created_at DESC
-      LIMIT ?
-    `,
-      )
-      .all(...params) as MemoryRow[];
+    const rows: MemoryRow[] = await repo.findRecentWithEmbeddings(excludeId, projectId, 500);
 
     // Calculate cosine similarity
     const scored: (MemoryRow & { similarity: number })[] = [];
@@ -407,15 +378,8 @@ export class RelationExtractor {
 
   // ── Helpers ────────────────────────────────────────────────
 
-  private loadMemory(memoryId: string): MemoryRow | null {
-    return this.db
-      .prepare(
-        `
-      SELECT id, content, type, level, importance, tags, embedding, created_at, project_id
-      FROM memories WHERE id = ?
-    `,
-      )
-      .get(memoryId) as MemoryRow | null;
+  private async loadMemory(memoryId: string): Promise<MemoryRow | null> {
+    return getMemoryRepository().getById(memoryId);
   }
 
   private sharesTags(a: MemoryRow, b: MemoryRow): boolean {
@@ -443,10 +407,4 @@ export class RelationExtractor {
     return denominator === 0 ? 0 : dotProduct / denominator;
   }
 
-  /**
-   * Close database connection.
-   */
-  close(): void {
-    this.db?.close();
-  }
 }

--- a/packages/core/src/services/hooks/co-retrieval-hook.ts
+++ b/packages/core/src/services/hooks/co-retrieval-hook.ts
@@ -94,8 +94,8 @@ export class CoRetrievalHook {
   private async handleMemoryStored(
     payload: EventMap["memory:session-stored"],
   ): Promise<void> {
-    // Feature flag — off by default until value is validated
-    if (!process.env.TH0TH_CO_RETRIEVAL_HOOK) return;
+    // Feature flag — opt-in only; any value other than "true" keeps it off
+    if (process.env.TH0TH_CO_RETRIEVAL_HOOK !== "true") return;
 
     const { memoryId, projectId, sessionId } = payload;
 

--- a/packages/core/src/services/hooks/co-retrieval-hook.ts
+++ b/packages/core/src/services/hooks/co-retrieval-hook.ts
@@ -1,0 +1,175 @@
+/**
+ * CoRetrievalHook — Hebbian co-retrieval reinforcement
+ *
+ * When two session memories are stored in the same search session, they
+ * co-occur semantically. This hook creates or strengthens a RELATES_TO
+ * edge between them in the GraphStore, making those memories surface
+ * together in future neighborhood queries (th0th_optimized_context).
+ *
+ * Architecture decisions vs. the original spec:
+ *  - Uses GraphStore (SQLite) not Prisma — edges already live there.
+ *  - Uses MemoryRelationType.RELATES_TO — no new edge type/migration.
+ *  - Weights in [0, 1] — consistent with GraphStore design.
+ *  - Only the "retrieved" signal — richer signals (used_in_answer,
+ *    task_succeeded) have no emitter in the current system.
+ *  - No decay job — out of scope for MVP; edges are bounded by the
+ *    saturation cap instead.
+ *  - Opt-in via TH0TH_CO_RETRIEVAL_HOOK=true — safe rollout.
+ *
+ * Timing:
+ *  SearchSessionHook stores Memory(B), then emits "memory:session-stored".
+ *  At that point Memory(B) is already in the DB. This hook receives the
+ *  event, queries recent session memories → finds Memory(A), links A↔B.
+ */
+
+import { logger, MemoryRelationType } from "@th0th-ai/shared";
+import { eventBus } from "../events/event-bus.js";
+import type { EventMap } from "../events/event-bus.js";
+import { GraphStore } from "../graph/graph-store.js";
+import { getMemoryRepository } from "../../data/memory/memory-repository-factory.js";
+import type { MemoryRepositoryPg } from "../../data/memory/memory-repository-pg.js";
+
+const INITIAL_WEIGHT = 0.15;
+const DELTA = 0.1;
+const MAX_WEIGHT = 0.85;
+const SESSION_WINDOW_MS = 10 * 60 * 1000; // 10-minute co-session window
+const MAX_PEERS = 5;                        // limit combinatorial pairs
+const AUTO_SEARCH_TAG = "auto:search-session";
+
+/** Subset of GraphStore used by CoRetrievalHook — injectable for testing. */
+export interface IGraphStoreEdges {
+  getEdge(sourceId: string, targetId: string, relationType: MemoryRelationType): any;
+  createEdge(sourceId: string, targetId: string, relationType: MemoryRelationType, opts?: any): any;
+  incrementEdgeWeight(sourceId: string, targetId: string, relationType: MemoryRelationType, delta: number, maxWeight?: number): boolean;
+}
+
+export class CoRetrievalHook {
+  private static instance: CoRetrievalHook | null = null;
+  private unsubscribe: (() => void) | null = null;
+  private readonly graphStore: IGraphStoreEdges;
+
+  private constructor(graphStore?: IGraphStoreEdges) {
+    this.graphStore = graphStore ?? GraphStore.getInstance();
+  }
+
+  static getInstance(): CoRetrievalHook {
+    if (!CoRetrievalHook.instance) {
+      CoRetrievalHook.instance = new CoRetrievalHook();
+    }
+    return CoRetrievalHook.instance;
+  }
+
+  /** Create an isolated instance with injected dependencies — for testing only. */
+  static createForTest(
+    graphStore: IGraphStoreEdges,
+    repo?: { findRecentByTag: MemoryRepositoryPg["findRecentByTag"] },
+  ): CoRetrievalHook {
+    const hook = new CoRetrievalHook(graphStore);
+    if (repo) (hook as any)._testRepo = repo;
+    return hook;
+  }
+
+  /** Register the hook. Safe to call multiple times — only registers once. */
+  register(): void {
+    if (this.unsubscribe) return;
+    this.unsubscribe = eventBus.subscribe("memory:session-stored", (payload) => {
+      void this.handleMemoryStored(payload);
+    });
+    logger.debug("CoRetrievalHook registered");
+  }
+
+  /** Unregister the hook (useful in tests). */
+  unregisterHook(): void {
+    this.unsubscribe?.();
+    this.unsubscribe = null;
+    logger.debug("CoRetrievalHook unregistered");
+  }
+
+  /** Reset singleton (test utility). */
+  static reset(): void {
+    CoRetrievalHook.instance?.unregisterHook();
+    CoRetrievalHook.instance = null;
+  }
+
+  private async handleMemoryStored(
+    payload: EventMap["memory:session-stored"],
+  ): Promise<void> {
+    // Feature flag — off by default until value is validated
+    if (!process.env.TH0TH_CO_RETRIEVAL_HOOK) return;
+
+    const { memoryId, projectId, sessionId } = payload;
+
+    let peers: Array<{ id: string }>;
+    try {
+      peers = await this.findPeers(memoryId, projectId, sessionId);
+    } catch (err) {
+      logger.warn("CoRetrievalHook: peer lookup failed", {
+        error: (err as Error).message,
+        memoryId,
+      });
+      return;
+    }
+
+    if (peers.length === 0) return;
+
+    let created = 0;
+    let reinforced = 0;
+
+    for (const peer of peers.slice(0, MAX_PEERS)) {
+      // Deterministic pair ordering prevents duplicate edges (A↔B == B↔A)
+      const [from, to] = [memoryId, peer.id].sort();
+
+      const existing = this.graphStore.getEdge(from, to, MemoryRelationType.RELATES_TO);
+
+      if (existing) {
+        const ok = this.graphStore.incrementEdgeWeight(
+          from,
+          to,
+          MemoryRelationType.RELATES_TO,
+          DELTA,
+          MAX_WEIGHT,
+        );
+        if (ok) reinforced++;
+      } else {
+        const edge = this.graphStore.createEdge(from, to, MemoryRelationType.RELATES_TO, {
+          weight: INITIAL_WEIGHT,
+          evidence: "co-retrieved in session",
+          autoExtracted: true,
+        });
+        if (edge) created++;
+      }
+    }
+
+    if (created > 0 || reinforced > 0) {
+      logger.debug("CoRetrievalHook: edges updated", {
+        memoryId,
+        created,
+        reinforced,
+        peers: peers.length,
+      });
+    }
+  }
+
+  private async findPeers(
+    memoryId: string,
+    projectId: string | undefined,
+    sessionId: string | undefined,
+  ): Promise<Array<{ id: string }>> {
+    // Allow test injection via createForTest
+    const repo: any = (this as any)._testRepo ?? (getMemoryRepository() as MemoryRepositoryPg);
+
+    // The method is only available on the Pg implementation.
+    // If running against SQLite repo in tests, skip gracefully.
+    if (typeof repo.findRecentByTag !== "function") return [];
+
+    return repo.findRecentByTag(AUTO_SEARCH_TAG, {
+      sessionId,
+      projectId,
+      excludeId: memoryId,
+      sinceMs: Date.now() - SESSION_WINDOW_MS,
+      limit: MAX_PEERS,
+    });
+  }
+}
+
+export const coRetrievalHook = CoRetrievalHook.getInstance();

--- a/packages/core/src/services/hooks/search-session-hook.ts
+++ b/packages/core/src/services/hooks/search-session-hook.ts
@@ -1,0 +1,126 @@
+/**
+ * SearchSessionHook
+ *
+ * Subscribes to "search:completed" events on the EventBus and automatically
+ * stores a lightweight session memory for every search that returns results.
+ *
+ * This creates an "intermediate memory" layer that bridges ephemeral search
+ * context (lost on compaction) and explicit persistent memories (th0th_remember).
+ *
+ * Design decisions:
+ *  - Non-blocking: store failures are logged but never surfaced to callers.
+ *  - Dedup: same (sessionId, projectId, query) is not stored twice within DEDUP_TTL_MS.
+ *  - Low importance (0.3): the temporal score and access reinforcement in
+ *    MemoryService naturally elevate memories that are accessed repeatedly.
+ *  - Prunes the dedup map when it grows beyond MAX_DEDUP_ENTRIES to avoid leaks.
+ */
+
+import { logger, MemoryType } from "@th0th-ai/shared";
+import { eventBus } from "../events/event-bus.js";
+import type { EventMap } from "../events/event-bus.js";
+import { MemoryController } from "../../controllers/memory-controller.js";
+
+const DEDUP_TTL_MS = 60_000;
+const MAX_DEDUP_ENTRIES = 500;
+
+export class SearchSessionHook {
+  private static instance: SearchSessionHook | null = null;
+
+  private unsubscribe: (() => void) | null = null;
+  /** dedup key → last stored timestamp */
+  private readonly recentKeys = new Map<string, number>();
+
+  private constructor() {}
+
+  static getInstance(): SearchSessionHook {
+    if (!SearchSessionHook.instance) {
+      SearchSessionHook.instance = new SearchSessionHook();
+    }
+    return SearchSessionHook.instance;
+  }
+
+  /** Register the hook. Safe to call multiple times — only registers once. */
+  register(): void {
+    if (this.unsubscribe) return;
+    this.unsubscribe = eventBus.subscribe("search:completed", (payload) => {
+      void this.handleSearchCompleted(payload);
+    });
+    logger.debug("SearchSessionHook registered");
+  }
+
+  /** Unregister the hook (useful in tests). */
+  unregisterHook(): void {
+    this.unsubscribe?.();
+    this.unsubscribe = null;
+    logger.debug("SearchSessionHook unregistered");
+  }
+
+  /** Reset singleton (test utility). */
+  static reset(): void {
+    SearchSessionHook.instance?.unregisterHook();
+    SearchSessionHook.instance = null;
+  }
+
+  private async handleSearchCompleted(
+    payload: EventMap["search:completed"],
+  ): Promise<void> {
+    const { query, projectId, sessionId, results, resultCount } = payload;
+
+    if (resultCount === 0) return;
+
+    // Dedup: skip if same (session, project, query) was stored recently
+    const dedupKey = `${sessionId ?? ""}:${projectId}:${query}`;
+    const now = Date.now();
+    const lastStored = this.recentKeys.get(dedupKey);
+    if (lastStored !== undefined && now - lastStored < DEDUP_TTL_MS) return;
+
+    this.recentKeys.set(dedupKey, now);
+    this.pruneDedup(now);
+
+    const top3 = results
+      .slice(0, 3)
+      .map((r) => r.filePath)
+      .join(", ");
+
+    const content = `Search[${projectId}]: "${query}" → ${top3}`;
+
+    try {
+      const stored = await MemoryController.getInstance().store({
+        content,
+        type: MemoryType.CONVERSATION,
+        projectId,
+        sessionId,
+        importance: 0.3,
+        tags: ["auto:search-session", "auto:search"],
+      });
+
+      logger.debug("SearchSessionHook: memory stored", {
+        projectId,
+        query: query.slice(0, 60),
+        resultCount,
+      });
+
+      eventBus.publish("memory:session-stored", {
+        memoryId: stored.memoryId,
+        projectId,
+        sessionId,
+        query,
+      });
+    } catch (err) {
+      logger.warn("SearchSessionHook: store failed (best-effort)", {
+        error: (err as Error).message,
+        projectId,
+        query: query.slice(0, 60),
+      });
+    }
+  }
+
+  private pruneDedup(now: number): void {
+    if (this.recentKeys.size <= MAX_DEDUP_ENTRIES) return;
+    for (const [k, ts] of this.recentKeys) {
+      if (now - ts > DEDUP_TTL_MS) this.recentKeys.delete(k);
+    }
+  }
+}
+
+export const searchSessionHook = SearchSessionHook.getInstance();

--- a/packages/core/src/services/hooks/search-session-hook.ts
+++ b/packages/core/src/services/hooks/search-session-hook.ts
@@ -117,8 +117,20 @@ export class SearchSessionHook {
 
   private pruneDedup(now: number): void {
     if (this.recentKeys.size <= MAX_DEDUP_ENTRIES) return;
+
+    // First pass: remove expired entries
     for (const [k, ts] of this.recentKeys) {
       if (now - ts > DEDUP_TTL_MS) this.recentKeys.delete(k);
+    }
+
+    // Hard cap: if still over limit, evict oldest entries (insertion order)
+    if (this.recentKeys.size > MAX_DEDUP_ENTRIES) {
+      const excess = this.recentKeys.size - MAX_DEDUP_ENTRIES;
+      let evicted = 0;
+      for (const k of this.recentKeys.keys()) {
+        this.recentKeys.delete(k);
+        if (++evicted >= excess) break;
+      }
     }
   }
 }

--- a/packages/core/src/services/index.ts
+++ b/packages/core/src/services/index.ts
@@ -5,6 +5,7 @@
 // Search
 export { ContextualSearchRLM } from "./search/contextual-search-rlm.js";
 export { SearchCache } from "./search/search-cache.js";
+export { getSearchCache } from "./search/cache-factory.js";
 export { SearchAnalytics } from "./search/search-analytics.js";
 export { SearchCacheWarmup } from "./search/search-warmup.js";
 export { IndexManager } from "./search/index-manager.js";
@@ -95,6 +96,10 @@ export type {
 // Events
 export { eventBus, EventBus } from "./events/event-bus.js";
 export type { EventMap, EventName } from "./events/event-bus.js";
+
+// Hooks
+export { SearchSessionHook, searchSessionHook } from "./hooks/search-session-hook.js";
+export { CoRetrievalHook, coRetrievalHook } from "./hooks/co-retrieval-hook.js";
 
 // Metrics (token savings observability)
 export { TokenMetrics } from "./metrics/token-metrics.js";

--- a/packages/core/src/services/query/prisma-client.ts
+++ b/packages/core/src/services/query/prisma-client.ts
@@ -11,6 +11,27 @@ import { logger } from "@th0th-ai/shared";
 let prismaInstance: PrismaClient | null = null;
 let prismaPool: import('pg').Pool | null = null;
 
+/**
+ * @internal
+ */
+export const _adapters = {
+  loadPg(): typeof import('pg') {
+    return require('pg') as typeof import('pg');
+  },
+  loadPrismaPg(): typeof import('@prisma/adapter-pg') {
+    return require('@prisma/adapter-pg') as typeof import('@prisma/adapter-pg');
+  },
+  loadPrismaBunSqlite(): typeof import('prisma-adapter-bun-sqlite') {
+    return require('prisma-adapter-bun-sqlite') as typeof import('prisma-adapter-bun-sqlite');
+  },
+};
+
+/** @internal — resets the singleton; call in afterEach during unit tests only */
+export function _resetPrismaForTesting(): void {
+  prismaInstance = null;
+  prismaPool = null;
+}
+
 export function getPrismaClient(): PrismaClient {
   if (!prismaInstance) {
     const databaseUrl = process.env.DATABASE_URL;
@@ -19,15 +40,11 @@ export function getPrismaClient(): PrismaClient {
     const isPostgres = databaseUrl?.startsWith('postgres');
 
     if (isPostgres) {
-      // Bun supports require() in ESM modules as a synchronous dynamic import.
-      // We use it here intentionally: getPrismaClient() is called synchronously
-      // at module init time in many places, making async import() impractical.
-      // This is Bun-specific and will not work in vanilla Node.js ESM.
       let pool: import('pg').Pool;
       let PrismaPg: typeof import('@prisma/adapter-pg').PrismaPg;
       try {
-        const pg = require('pg') as typeof import('pg');
-        const adapterPg = require('@prisma/adapter-pg') as typeof import('@prisma/adapter-pg');
+        const pg = _adapters.loadPg();
+        const adapterPg = _adapters.loadPrismaPg();
         pool = new pg.Pool({
           connectionString: databaseUrl,
           max: 10,
@@ -39,24 +56,23 @@ export function getPrismaClient(): PrismaClient {
         });
         PrismaPg = adapterPg.PrismaPg;
       } catch (e) {
-        logger.warn('pg or @prisma/adapter-pg not available, falling back to no adapter');
-        prismaInstance = new PrismaClient();
-        return prismaInstance;
+        throw new Error(
+          'pg or @prisma/adapter-pg is required for PostgreSQL mode but could not be loaded. Run: bun add pg @prisma/adapter-pg'
+        );
       }
       prismaPool = pool;
       const adapter = new PrismaPg(pool as any);
       prismaInstance = new PrismaClient({ adapter });
       logger.info('Prisma Client initialized with PostgreSQL (pg adapter)');
     } else {
-      // Same pattern: synchronous require() for Bun ESM compatibility.
       let PrismaBunSqlite: typeof import('prisma-adapter-bun-sqlite').PrismaBunSqlite;
       try {
-        const bunAdapter = require('prisma-adapter-bun-sqlite') as typeof import('prisma-adapter-bun-sqlite');
+        const bunAdapter = _adapters.loadPrismaBunSqlite();
         PrismaBunSqlite = bunAdapter.PrismaBunSqlite;
       } catch (e) {
-        logger.warn('prisma-adapter-bun-sqlite not available, falling back to no adapter');
-        prismaInstance = new PrismaClient();
-        return prismaInstance;
+        throw new Error(
+          'prisma-adapter-bun-sqlite is required for SQLite mode but could not be loaded. Run: bun add prisma-adapter-bun-sqlite'
+        );
       }
       const dataDir = config.get("dataDir");
       const th0thDbPath = path.join(dataDir, "th0th.db");

--- a/packages/core/src/services/search/ignore-patterns.ts
+++ b/packages/core/src/services/search/ignore-patterns.ts
@@ -26,6 +26,21 @@ export const DEFAULT_IGNORES = [
   "**/generated/**",
   "**/*.generated.*",
   "**/*.d.ts",
+  // Tests and benchmarks: usually noise for code search (test fixtures often
+  // contain query keywords verbatim, polluting recall of the real
+  // implementation). Opt back in per-search via the `include` filter.
+  "**/__tests__/**",
+  "**/tests/**",
+  "**/*.test.ts",
+  "**/*.test.tsx",
+  "**/*.test.js",
+  "**/*.test.jsx",
+  "**/*.spec.ts",
+  "**/*.spec.tsx",
+  "**/*.spec.js",
+  "**/*.spec.jsx",
+  "**/benchmarks/**",
+  "**/fixtures/**",
   "**/*.wasm*",
   "**/*.min.*",
   "**/*.map",

--- a/packages/core/src/services/search/smart-chunker.ts
+++ b/packages/core/src/services/search/smart-chunker.ts
@@ -113,8 +113,14 @@ export function smartChunk(
       break;
   }
 
-  // Post-processing: merge tiny chunks, split oversized ones
-  chunks = postProcess(chunks, cfg);
+  // Post-processing: merge tiny chunks, split oversized ones.
+  // Reserve ~250 chars for the file/label context header that is prepended
+  // afterwards so the final chunk never exceeds cfg.maxChunkChars.
+  const HEADER_BUDGET = 250;
+  const postCfg = cfg.maxChunkChars > HEADER_BUDGET
+    ? { ...cfg, maxChunkChars: cfg.maxChunkChars - HEADER_BUDGET }
+    : cfg;
+  chunks = postProcess(chunks, postCfg);
 
   // Add file context prefix for better embedding quality.
   //

--- a/packages/core/src/services/search/smart-chunker.ts
+++ b/packages/core/src/services/search/smart-chunker.ts
@@ -52,14 +52,21 @@ export interface ChunkerConfig {
   fixedChunkSize: number;
   /** Whether to add file-path context prefix to each chunk */
   addFileContext: boolean;
+  /**
+   * Max characters per chunk. Takes precedence over line count for files with
+   * very long lines (minified JS, single-line JSON, i18n files). Should stay
+   * below the embedding provider's maxChars to avoid truncation.
+   */
+  maxChunkChars: number;
 }
 
 const DEFAULT_CONFIG: ChunkerConfig = {
-  maxChunkLines: 200, // ~4000 chars avg, fits within MAX_CHARS without truncation
+  maxChunkLines: 200,
   minChunkLines: 5,
   codeChunkTarget: 80,
   fixedChunkSize: 50,
   addFileContext: true,
+  maxChunkChars: 7500, // 90% of 8000 char Ollama maxChars default, leaves room for file-context prefix
 };
 
 /**
@@ -109,12 +116,33 @@ export function smartChunk(
   // Post-processing: merge tiny chunks, split oversized ones
   chunks = postProcess(chunks, cfg);
 
-  // Add file context prefix for better embedding quality
+  // Add file context prefix for better embedding quality.
+  //
+  // The label (Class.method, top-level fn name, etc.) is the highest-signal
+  // token for retrieval — repeat it 3x in the header so the embedding vector
+  // is biased toward it. Known RAG trick for transformer-based embeddings:
+  // token frequency in the input shifts attention.
+  //
+  // BUT: do NOT repeat for tiny chunks (< 5 lines). A 1-line constant like
+  // `const REINDEX_FILE_THRESHOLD = 15` would otherwise outrank the actual
+  // implementation when the query mentions "reindex" — the label match is
+  // trivial and not informative. For tiny chunks, the label appears once
+  // (via `// Section:`) which is enough.
+  const REPEAT_MIN_LINES = 5;
   if (cfg.addFileContext) {
-    chunks = chunks.map((chunk) => ({
-      ...chunk,
-      content: `// File: ${relativePath}\n${chunk.label ? `// Section: ${chunk.label}\n` : ""}${chunk.content}`,
-    }));
+    chunks = chunks.map((chunk) => {
+      const lineCount = chunk.content.split("\n").length;
+      const repeat = chunk.label && lineCount >= REPEAT_MIN_LINES;
+      const labelHeader = chunk.label
+        ? repeat
+          ? `// Section: ${chunk.label}\n// ${chunk.label}\n// ${chunk.label}\n`
+          : `// Section: ${chunk.label}\n`
+        : "";
+      return {
+        ...chunk,
+        content: `// File: ${relativePath}\n${labelHeader}${chunk.content}`,
+      };
+    });
   }
 
   // Filter out empty chunks
@@ -132,8 +160,20 @@ export function smartChunk(
  *   like "Installation > Prerequisites"
  * - Content before the first heading is its own chunk ("preamble")
  * - Code blocks (```) are treated as opaque (headings inside them are ignored)
+ * - If the file has NO headings at all, fall back to fixed chunking so we
+ *   don't emit a single mega-chunk that matches every query.
  */
 function chunkMarkdown(content: string, cfg: ChunkerConfig): Chunk[] {
+  // Quick scan: if no headings exist, fall back to fixed chunks.
+  // Otherwise the whole file becomes one "preamble" that wins every search
+  // by virtue of containing every keyword in the query.
+  const hasHeading = /^\s*#{1,6}\s+/m.test(content);
+  if (!hasHeading) return chunkFixed(content, cfg);
+
+  return chunkMarkdownByHeadings(content, cfg);
+}
+
+function chunkMarkdownByHeadings(content: string, _cfg: ChunkerConfig): Chunk[] {
   const lines = content.split("\n");
   const chunks: Chunk[] = [];
 
@@ -385,163 +425,205 @@ function chunkYAML(content: string, cfg: ChunkerConfig): Chunk[] {
 // --- Code Chunker (improved version of original) ---
 
 /**
- * Split code by semantic blocks (functions, classes, etc.)
+ * Split code by semantic blocks (functions, classes, methods).
  *
- * Improvements over original:
- * - More patterns: Python (def/class), Go (func), Rust (fn/impl/struct)
- * - Captures preceding comments/decorators as part of the chunk
- * - Limits individual chunk size (splits huge functions)
+ * Two-phase algorithm:
+ *
+ *   Phase 1 — find boundaries: scan once tracking brace depth.
+ *     - At depth 0: top-level declarations (class/interface/function/const/...)
+ *     - At depth = container.openDepth + 1 (one level inside a container):
+ *       method-like declarations (`name(...)`, `name<T>(...)`)
+ *     Pure-comment lines are skipped for boundary detection but do not
+ *     update brace depth (comments rarely contain raw braces).
+ *
+ *   Phase 2 — slice into chunks: walk back from each boundary to absorb
+ *     immediately-preceding doc comments / decorators (without crossing
+ *     the previous boundary). Lines before the first boundary become a
+ *     `imports` preamble chunk.
+ *
+ * This replaces the previous brace-counting accumulator, which had two
+ * bugs: (a) methods inside a class were never split (the whole class became
+ * one chunk because `isBlockStart` was only checked when `!inBlock`), and
+ * (b) the comment-buffer was emitted twice in some edge cases, producing
+ * overlapping chunk ranges.
  */
 function chunkCode(content: string, cfg: ChunkerConfig): Chunk[] {
   const lines = content.split("\n");
+  const boundaries = findCodeBoundaries(lines);
+
+  if (boundaries.length === 0) return chunkFixed(content, cfg);
+
+  // Compute realStart for each boundary (walk back over preceding doc comments
+  // / decorators, but never cross the previous boundary's line).
+  const realStarts: number[] = [];
+  for (let b = 0; b < boundaries.length; b++) {
+    const limit = b > 0 ? boundaries[b - 1].line + 1 : 0;
+    let s = boundaries[b].line;
+    while (s > limit) {
+      const prev = lines[s - 1].trimStart();
+      const isDoc =
+        prev.startsWith("//") ||
+        prev.startsWith("/*") ||
+        prev.startsWith("*") ||
+        prev.startsWith("///") ||
+        prev.startsWith("@") ||
+        prev.startsWith('"""');
+      if (isDoc) s--;
+      else break;
+    }
+    realStarts.push(s);
+  }
+
   const chunks: Chunk[] = [];
 
-  // Block start patterns for multiple languages
-  const blockPatterns = [
-    // TypeScript/JavaScript
-    /^\s*(export\s+)?(class|interface|type|enum)\s+\w+/,
-    /^\s*(export\s+)?(async\s+)?function\s+\w+/,
-    /^\s*(export\s+)?const\s+\w+\s*=\s*(async\s*)?\(/,
-    /^\s*(export\s+)?(async\s+)?\w+\s*\([^)]*\)\s*(:\s*\w+)?\s*\{/,
-    /^\s*describe\s*\(/, // test blocks
-    /^\s*it\s*\(/, // test cases
-    // Python
-    /^\s*(async\s+)?def\s+\w+/,
-    /^\s*class\s+\w+/,
-    // Go
-    /^\s*func\s+(\([^)]+\)\s+)?\w+/,
-    // Rust
-    /^\s*(pub\s+)?(async\s+)?fn\s+\w+/,
-    /^\s*(pub\s+)?struct\s+\w+/,
-    /^\s*(pub\s+)?enum\s+\w+/,
-    /^\s*(pub\s+)?impl\s+/,
-    /^\s*(pub\s+)?trait\s+/,
-    // C/C++
-    /^\s*(\w+\s+)+\w+\s*\([^)]*\)\s*\{/,
-  ];
+  // Preamble: anything before the first boundary's realStart (imports,
+  // file-level constants, file JSDoc).
+  if (realStarts[0] > 0) {
+    const preamble = lines.slice(0, realStarts[0]);
+    if (preamble.some((l) => l.trim())) {
+      chunks.push({
+        content: preamble.join("\n"),
+        lineStart: 1,
+        lineEnd: realStarts[0],
+        type: "code_block",
+        label: "imports",
+      });
+    }
+  }
 
-  let currentChunk: { lines: string[]; startLine: number } | null = null;
-  let braceCount = 0;
-  let inBlock = false;
+  for (let b = 0; b < boundaries.length; b++) {
+    const start = realStarts[b];
+    const end = b + 1 < realStarts.length ? realStarts[b + 1] : lines.length;
+    const slice = lines.slice(start, end);
+    if (!slice.some((l) => l.trim())) continue;
+    const label = boundaries[b].container
+      ? `${boundaries[b].container}.${boundaries[b].label}`
+      : boundaries[b].label;
+    chunks.push({
+      content: slice.join("\n"),
+      lineStart: start + 1,
+      lineEnd: end,
+      type: "code_block",
+      label,
+    });
+  }
 
-  // Track preceding comment/decorator lines to include with the block
-  let commentBuffer: string[] = [];
-  let commentBufferStart = -1;
+  return chunks;
+}
+
+interface CodeBoundary {
+  /** 0-indexed line where the declaration starts */
+  line: number;
+  /** Symbol name (e.g. "ParseStage", "extractJsSymbols") */
+  label: string;
+  /** Outer container name when this boundary is a method */
+  container?: string;
+}
+
+const RESERVED_KEYWORDS = new Set([
+  "if", "for", "while", "switch", "return", "throw", "catch",
+  "do", "try", "else", "case", "with", "yield", "await",
+]);
+
+/** Top-level container declarations (class/interface/enum/namespace/trait/impl) */
+const CONTAINER_RE =
+  /^(?:export\s+(?:default\s+)?)?(?:abstract\s+)?(?:class|interface|enum|namespace|trait|impl)\s+(\w+)/;
+
+/** Top-level non-container declarations (function/const/let/var/type/struct/fn/def/func) */
+const TOP_LEVEL_RE =
+  /^(?:export\s+(?:default\s+)?)?(?:async\s+)?(?:function|const|let|var|type|struct|fn|def|func)\s+(\w+)/;
+
+/** Method-like declarations inside a class body: identifier followed by `(` or `<` */
+const METHOD_RE =
+  /^(?:public\s+|private\s+|protected\s+|static\s+|readonly\s+|override\s+|async\s+|abstract\s+|get\s+|set\s+)*(\w+)\s*[(<]/;
+
+function findCodeBoundaries(lines: string[]): CodeBoundary[] {
+  const boundaries: CodeBoundary[] = [];
+  const containerStack: { name: string; openDepth: number }[] = [];
+  let depth = 0;
+  let inBlockComment = false;
 
   for (let i = 0; i < lines.length; i++) {
     const line = lines[i];
     const trimmed = line.trimStart();
 
-    // Track comments and decorators that precede blocks
+    // Block comment continuations
+    if (inBlockComment) {
+      if (line.includes("*/")) inBlockComment = false;
+      continue;
+    }
+    if (trimmed.startsWith("/*") && !trimmed.includes("*/")) {
+      inBlockComment = true;
+      continue;
+    }
+    // Skip empty / pure comment lines (no brace updates, no boundary)
     if (
-      !inBlock &&
-      (trimmed.startsWith("//") ||
-        trimmed.startsWith("/*") ||
-        trimmed.startsWith("*") ||
-        trimmed.startsWith("#") ||
-        trimmed.startsWith("@") ||
-        trimmed.startsWith('"""') ||
-        trimmed.startsWith("///"))
+      !trimmed ||
+      trimmed.startsWith("//") ||
+      trimmed.startsWith("///") ||
+      trimmed.startsWith("*")
     ) {
-      if (commentBuffer.length === 0) {
-        commentBufferStart = i;
-      }
-      commentBuffer.push(line);
       continue;
     }
 
-    const isBlockStart = blockPatterns.some((pattern) => pattern.test(line));
-
-    if (isBlockStart && !inBlock) {
-      // Save previous chunk if it has content
-      if (currentChunk && currentChunk.lines.length > 0) {
-        chunks.push({
-          content: currentChunk.lines.join("\n"),
-          lineStart: currentChunk.startLine,
-          lineEnd: Math.max(currentChunk.startLine, i),
-          type: "code_block",
+    // Boundary detection BEFORE updating depth (depth still reflects the state
+    // at the start of this line)
+    if (depth === 0) {
+      const c = CONTAINER_RE.exec(trimmed);
+      if (c) {
+        boundaries.push({ line: i, label: c[1] });
+        containerStack.push({ name: c[1], openDepth: 0 });
+      } else {
+        const t = TOP_LEVEL_RE.exec(trimmed);
+        if (t) boundaries.push({ line: i, label: t[1] });
+      }
+    } else if (
+      containerStack.length > 0 &&
+      depth === containerStack[containerStack.length - 1].openDepth + 1
+    ) {
+      const m = METHOD_RE.exec(trimmed);
+      if (m && !RESERVED_KEYWORDS.has(m[1])) {
+        boundaries.push({
+          line: i,
+          label: m[1],
+          container: containerStack[containerStack.length - 1].name,
         });
       }
+    }
 
-      // Start new chunk, including preceding comments
-      const blockLines =
-        commentBuffer.length > 0 ? [...commentBuffer, line] : [line];
-      const startLine =
-        commentBuffer.length > 0 ? commentBufferStart + 1 : i + 1;
+    // Update depth using the line's brace counts (strings/regex/comments
+    // stripped first, so braces inside `"{"`, `/\{/`, etc. don't drift the
+    // depth — this matters for files like parsers that contain regex
+    // literals with curly braces).
+    depth += netBraceDelta(line);
 
-      currentChunk = {
-        lines: blockLines,
-        startLine,
-      };
-      commentBuffer = [];
-      inBlock = true;
-      braceCount =
-        (line.match(/\{/g) || []).length - (line.match(/\}/g) || []).length;
-    } else if (inBlock && currentChunk) {
-      currentChunk.lines.push(line);
-      braceCount +=
-        (line.match(/\{/g) || []).length - (line.match(/\}/g) || []).length;
-
-      // End of block: brace closed OR safety valve (prevents infinite accumulation)
-      const shouldClose =
-        (braceCount <= 0 && trimmed.endsWith("}")) ||
-        currentChunk.lines.length >= cfg.maxChunkLines;
-      if (shouldClose) {
-        chunks.push({
-          content: currentChunk.lines.join("\n"),
-          lineStart: currentChunk.startLine,
-          lineEnd: i + 1,
-          type: "code_block",
-        });
-        currentChunk = null;
-        inBlock = false;
-        braceCount = 0;
-        commentBuffer = [];
-      }
-    } else if (!inBlock && line.trim()) {
-      // Flush comment buffer into current chunk
-      if (commentBuffer.length > 0) {
-        if (!currentChunk) {
-          currentChunk = {
-            lines: [],
-            startLine: commentBufferStart + 1,
-          };
-        }
-        currentChunk.lines.push(...commentBuffer);
-        commentBuffer = [];
-      }
-
-      if (!currentChunk) {
-        currentChunk = {
-          lines: [],
-          startLine: i + 1,
-        };
-      }
-      currentChunk.lines.push(line);
+    // Pop containers whose scope just closed
+    while (
+      containerStack.length > 0 &&
+      depth <= containerStack[containerStack.length - 1].openDepth
+    ) {
+      containerStack.pop();
     }
   }
 
-  // Flush remaining comment buffer
-  if (commentBuffer.length > 0 && currentChunk) {
-    currentChunk.lines.push(...commentBuffer);
-  }
+  return boundaries;
+}
 
-  // Final chunk
-  if (currentChunk && currentChunk.lines.length > 0) {
-    chunks.push({
-      content: currentChunk.lines.join("\n"),
-      lineStart: currentChunk.startLine,
-      lineEnd: lines.length,
-      type: "code_block",
-    });
-  }
-
-  // If no semantic blocks found, use fixed chunking
-  if (chunks.length === 0) {
-    return chunkFixed(content, cfg);
-  }
-
-  return chunks;
+/**
+ * Brace-depth delta for a single line, ignoring braces inside string,
+ * template, regex, and inline comment literals. Heuristic — does not handle
+ * template-literal `${}` interpolation expressions correctly, but those are
+ * rare enough at the line level that the drift is bounded.
+ */
+function netBraceDelta(line: string): number {
+  const stripped = line
+    .replace(/\/\*.*?\*\//g, "") // inline /* ... */
+    .replace(/\/\/.*$/, "") // // line comment
+    .replace(/'(?:\\.|[^'\\])*'/g, "''") // 'single'
+    .replace(/"(?:\\.|[^"\\])*"/g, '""') // "double"
+    .replace(/`(?:\\.|[^`\\])*`/g, "``") // `template` (no ${} support)
+    .replace(/\/(?:\\.|[^/\\\n])+\/[gimsuy]*/g, "//"); // /regex/flags
+  return (stripped.match(/\{/g) || []).length - (stripped.match(/\}/g) || []).length;
 }
 
 // --- Fixed Chunker (fallback) ---
@@ -583,23 +665,47 @@ function postProcess(chunks: Chunk[], cfg: ChunkerConfig): Chunk[] {
 
   for (const chunk of chunks) {
     const lineCount = chunk.content.split("\n").length;
+    const charCount = chunk.content.length;
 
-    // Split oversized chunks
-    if (lineCount > cfg.maxChunkLines) {
-      const subChunks = splitOversizedChunk(chunk, cfg);
+    // For code blocks, use the (smaller) codeChunkTarget so that long methods
+    // (like a 180-line controller `calculate` with multiple validation
+    // sub-blocks) get split into focused pieces. Embeddings of huge methods
+    // wash out semantic signal — splitting recovers recall.
+    const lineLimit =
+      chunk.type === "code_block" ? cfg.codeChunkTarget : cfg.maxChunkLines;
+
+    // Split oversized chunks (by lines OR by chars — long single lines bypass line-based limit)
+    if (lineCount > lineLimit || charCount > cfg.maxChunkChars) {
+      const subChunks = splitOversizedChunk(
+        chunk,
+        chunk.type === "code_block"
+          ? { ...cfg, maxChunkLines: cfg.codeChunkTarget }
+          : cfg,
+      );
       result.push(...subChunks);
       continue;
     }
 
-    // Merge tiny chunks with previous
+    // Merge tiny chunks with previous — but NEVER merge code chunks that
+    // carry an explicit semantic label (method/function name). A 3-line
+    // getter is small but discoverable; merging it into a neighbor erases
+    // it from search.
+    if (chunk.label && chunk.type === "code_block") {
+      result.push(chunk);
+      continue;
+    }
     if (
       lineCount < cfg.minChunkLines &&
       result.length > 0
     ) {
       const prev = result[result.length - 1];
       const prevLineCount = prev.content.split("\n").length;
-      // Only merge if combined size is reasonable
-      if (prevLineCount + lineCount <= cfg.maxChunkLines) {
+      const prevCharCount = prev.content.length;
+      // Only merge if combined size is reasonable (both line and char limits)
+      if (
+        prevLineCount + lineCount <= cfg.maxChunkLines &&
+        prevCharCount + charCount + 1 <= cfg.maxChunkChars
+      ) {
         prev.content += "\n" + chunk.content;
         prev.lineEnd = chunk.lineEnd;
         // Keep the previous chunk's label
@@ -615,49 +721,105 @@ function postProcess(chunks: Chunk[], cfg: ChunkerConfig): Chunk[] {
 
 /**
  * Split an oversized chunk into smaller pieces.
- * Tries to split at blank lines or heading boundaries.
+ *
+ * Split is capped by both line count (cfg.maxChunkLines) and char count
+ * (cfg.maxChunkChars). Prefers blank-line boundaries when possible. A single
+ * line longer than maxChunkChars is further split by characters, preferring
+ * semantic separators (`; , } `) before a hard cut.
  */
 function splitOversizedChunk(chunk: Chunk, cfg: ChunkerConfig): Chunk[] {
   const lines = chunk.content.split("\n");
-  const target = cfg.maxChunkLines;
+  const targetLines = cfg.maxChunkLines;
+  const maxChars = cfg.maxChunkChars;
   const subChunks: Chunk[] = [];
+
+  const pushSub = (subLines: string[], startIdx: number, endIdx: number) => {
+    if (!subLines.some((l) => l.trim())) return;
+    subChunks.push({
+      content: subLines.join("\n"),
+      lineStart: chunk.lineStart + startIdx,
+      lineEnd: chunk.lineStart + endIdx - 1,
+      type: chunk.type,
+      label: chunk.label
+        ? `${chunk.label} (part ${subChunks.length + 1})`
+        : undefined,
+    });
+  };
 
   let start = 0;
   while (start < lines.length) {
-    let end = Math.min(start + target, lines.length);
+    // Single line exceeds maxChars: split that line by characters
+    if (lines[start].length > maxChars) {
+      const parts = splitLineByChars(lines[start], maxChars);
+      for (const part of parts) {
+        subChunks.push({
+          content: part,
+          lineStart: chunk.lineStart + start,
+          lineEnd: chunk.lineStart + start,
+          type: chunk.type,
+          label: chunk.label
+            ? `${chunk.label} (part ${subChunks.length + 1})`
+            : undefined,
+        });
+      }
+      start += 1;
+      continue;
+    }
 
-    // Try to find a natural break point (blank line) near the target
+    let end = Math.min(start + targetLines, lines.length);
+
+    // Shrink end until the slice fits within maxChars
+    while (end > start + 1) {
+      const sliceLen = lines.slice(start, end).reduce((s, l) => s + l.length + 1, -1);
+      if (sliceLen <= maxChars) break;
+      end--;
+    }
+
+    // Prefer a blank-line break in the final half of the window
     if (end < lines.length) {
-      let bestBreak = -1;
-      // Search backward from target for a blank line
-      for (let i = end; i > start + Math.floor(target * 0.5); i--) {
-        if (lines[i].trim() === "") {
-          bestBreak = i;
+      const minBreak = start + Math.max(1, Math.floor((end - start) * 0.5));
+      for (let i = end; i > minBreak; i--) {
+        if (lines[i]?.trim() === "") {
+          end = i;
           break;
         }
       }
-      if (bestBreak > start) {
-        end = bestBreak;
-      }
     }
 
-    const subLines = lines.slice(start, end);
-    if (subLines.some((l) => l.trim())) {
-      subChunks.push({
-        content: subLines.join("\n"),
-        lineStart: chunk.lineStart + start,
-        lineEnd: chunk.lineStart + end - 1,
-        type: chunk.type,
-        label: chunk.label
-          ? `${chunk.label} (part ${subChunks.length + 1})`
-          : undefined,
-      });
-    }
+    pushSub(lines.slice(start, end), start, end);
 
-    start = end;
+    // Safety: guarantee progress if the loop produced an empty slice
+    start = end === start ? start + 1 : end;
   }
 
   return subChunks;
+}
+
+/**
+ * Split a single overly long line into parts ≤ maxChars each.
+ * Prefers semantic separators (`;` > `,` > `}` > space) within the last 20%
+ * of each window. Falls back to a hard cut at maxChars.
+ */
+function splitLineByChars(line: string, maxChars: number): string[] {
+  const parts: string[] = [];
+  let remaining = line;
+  while (remaining.length > maxChars) {
+    const windowStart = Math.floor(maxChars * 0.8);
+    const window = remaining.substring(windowStart, maxChars);
+    let breakAt = -1;
+    for (const sep of [";", ",", "}", " "]) {
+      const idx = window.lastIndexOf(sep);
+      if (idx >= 0) {
+        breakAt = windowStart + idx + 1;
+        break;
+      }
+    }
+    if (breakAt < 0) breakAt = maxChars;
+    parts.push(remaining.substring(0, breakAt));
+    remaining = remaining.substring(breakAt);
+  }
+  if (remaining) parts.push(remaining);
+  return parts;
 }
 
 // --- Utilities ---

--- a/packages/core/src/services/symbol/symbol-graph.service.ts
+++ b/packages/core/src/services/symbol/symbol-graph.service.ts
@@ -78,6 +78,26 @@ export interface ListDefinitionsOptions {
   limit?: number;
 }
 
+export interface ProjectMapResult {
+  projectId: string;
+  stats: {
+    files: number;
+    chunks: number;
+    symbols: number;
+    status: string;
+    lastIndexedAt: string | null;
+  };
+  topCentralFiles: CentralityResult[];
+  symbolsByKind: Record<string, number>;
+  filesByLanguage: Record<string, number>;
+  recentFiles: Array<{ filePath: string; indexedAt: string | null }>;
+}
+
+export interface GetProjectMapOptions {
+  centralityLimit?: number;
+  recentLimit?: number;
+}
+
 // ─── Service ──────────────────────────────────────────────────────────────────
 
 export class SymbolGraphService {
@@ -254,6 +274,50 @@ export class SymbolGraphService {
       score: row.score,
       updatedAt: row.updated_at,
     }));
+  }
+
+  // ── project_map ─────────────────────────────────────────────────────────
+
+  /**
+   * Aggregate view of a project — stats, central files, symbol breakdown by
+   * kind, file count by language extension, and most-recently indexed files.
+   * Consumes symbol_files, symbol_definitions, and workspace metadata.
+   */
+  async getProjectMap(
+    projectId: string,
+    opts: GetProjectMapOptions = {},
+  ): Promise<ProjectMapResult | null> {
+    const centralityLimit = opts.centralityLimit ?? 20;
+    const recentLimit = opts.recentLimit ?? 10;
+
+    const repo = getSymbolRepository();
+    const workspace = await repo.getWorkspace(projectId);
+    if (!workspace) return null;
+
+    const [topCentralFiles, aggregates] = await Promise.all([
+      this.getTopCentralFiles(projectId, centralityLimit),
+      repo.getProjectMapAggregates(projectId, recentLimit),
+    ]);
+
+    return {
+      projectId,
+      stats: {
+        files: workspace.files_count,
+        chunks: workspace.chunks_count,
+        symbols: workspace.symbols_count,
+        status: workspace.status,
+        lastIndexedAt: workspace.last_indexed_at
+          ? new Date(workspace.last_indexed_at).toISOString()
+          : null,
+      },
+      topCentralFiles,
+      symbolsByKind: aggregates.symbolsByKind,
+      filesByLanguage: aggregates.filesByLanguage,
+      recentFiles: aggregates.recentFiles.map((r) => ({
+        filePath: r.filePath,
+        indexedAt: r.indexedAt ? new Date(r.indexedAt).toISOString() : null,
+      })),
+    };
   }
 
   // ── centrality recomputation ─────────────────────────────────────────────

--- a/packages/core/src/tools/search_project.ts
+++ b/packages/core/src/tools/search_project.ts
@@ -22,6 +22,7 @@ interface SearchProjectParams {
   exclude?: string[];
   explainScores?: boolean;
   format?: "json" | "toon";
+  sessionId?: string;
 }
 
 export class SearchProjectTool implements IToolHandler {

--- a/packages/core/src/tools/search_project.ts
+++ b/packages/core/src/tools/search_project.ts
@@ -91,6 +91,10 @@ export class SearchProjectTool implements IToolHandler {
         description: "Output format (json or toon)",
         default: "toon",
       },
+      sessionId: {
+        type: "string",
+        description: "Session ID for search hook scoping (enables session memory persistence)",
+      },
     },
     required: ["query", "projectId"],
   };

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@th0th-ai/shared",
-  "version": "1.0.3",
+  "version": "1.1.2",
   "author": "S1LV4",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/shared/src/config/index.ts
+++ b/packages/shared/src/config/index.ts
@@ -94,6 +94,14 @@ export interface ServerConfig {
   };
 }
 
+/** Read an env var as a number; falls back to `fallback` when unset, empty, or non-finite. */
+function envNum(key: string, fallback: number): number {
+  const s = process.env[key];
+  if (s === undefined || s === "") return fallback;
+  const n = Number(s);
+  return Number.isFinite(n) ? n : fallback;
+}
+
 /**
  * Get global data directory
  * Creates ~/.rlm/ directory for all projects
@@ -115,13 +123,13 @@ export const defaultConfig: ServerConfig = {
 
   cache: {
     l1: {
-      maxSize: Number(process.env.L1_CACHE_MAX_SIZE) || 100 * 1024 * 1024,
-      defaultTTL: Number(process.env.L1_CACHE_TTL) || 300,
+      maxSize: envNum("L1_CACHE_MAX_SIZE", 100 * 1024 * 1024),
+      defaultTTL: envNum("L1_CACHE_TTL", 300),
     },
     l2: {
       dbPath: process.env.CACHE_DB_PATH || path.join(getGlobalDataDir(), "cache.db"),
-      maxSize: Number(process.env.L2_CACHE_MAX_SIZE) || 500 * 1024 * 1024,
-      defaultTTL: Number(process.env.L2_CACHE_TTL) || 3600,
+      maxSize: envNum("L2_CACHE_MAX_SIZE", 500 * 1024 * 1024),
+      defaultTTL: envNum("L2_CACHE_TTL", 3600),
     },
     embedding: {
       dbPath: process.env.EMBEDDING_CACHE_DB_PATH || path.join(getGlobalDataDir(), "embedding-cache.db"),
@@ -143,8 +151,8 @@ export const defaultConfig: ServerConfig = {
 
   compression: {
     defaultStrategy: "code_structure",
-    minTokensForCompression: Number(process.env.MIN_TOKENS_FOR_COMPRESSION) || 100,
-    targetCompressionRatio: Number(process.env.TARGET_COMPRESSION_RATIO) || 0.7,
+    minTokensForCompression: envNum("MIN_TOKENS_FOR_COMPRESSION", 100),
+    targetCompressionRatio: envNum("TARGET_COMPRESSION_RATIO", 0.7),
     llm: {
       enabled: process.env.RLM_LLM_ENABLED === "true",
       baseUrl: process.env.RLM_LLM_BASE_URL || "https://api.openai.com/v1",
@@ -158,12 +166,12 @@ export const defaultConfig: ServerConfig = {
   },
 
   rateLimit: {
-    requestsPerMinute: Number(process.env.REQUESTS_PER_MINUTE) || 60,
-    tokensPerMinute: Number(process.env.TOKENS_PER_MINUTE) || 100000,
+    requestsPerMinute: envNum("REQUESTS_PER_MINUTE", 60),
+    tokensPerMinute: envNum("TOKENS_PER_MINUTE", 100000),
   },
 
   security: {
-    maxInputLength: Number(process.env.MAX_INPUT_LENGTH) || 100000,
+    maxInputLength: envNum("MAX_INPUT_LENGTH", 100000),
     sanitizeInputs: process.env.SANITIZE_INPUTS !== "false",
     maxIndexSize: 100000, // max files to index
     maxFileSize: 1024 * 1024, // 1MB per file

--- a/packages/shared/src/config/index.ts
+++ b/packages/shared/src/config/index.ts
@@ -115,16 +115,16 @@ export const defaultConfig: ServerConfig = {
 
   cache: {
     l1: {
-      maxSize: 100 * 1024 * 1024, // 100 MB
-      defaultTTL: 300, // 5 minutes
+      maxSize: Number(process.env.L1_CACHE_MAX_SIZE) || 100 * 1024 * 1024,
+      defaultTTL: Number(process.env.L1_CACHE_TTL) || 300,
     },
     l2: {
-      dbPath: path.join(getGlobalDataDir(), "cache.db"),
-      maxSize: 500 * 1024 * 1024, // 500 MB
-      defaultTTL: 3600, // 1 hour
+      dbPath: process.env.CACHE_DB_PATH || path.join(getGlobalDataDir(), "cache.db"),
+      maxSize: Number(process.env.L2_CACHE_MAX_SIZE) || 500 * 1024 * 1024,
+      defaultTTL: Number(process.env.L2_CACHE_TTL) || 3600,
     },
     embedding: {
-      dbPath: path.join(getGlobalDataDir(), "embedding-cache.db"),
+      dbPath: process.env.EMBEDDING_CACHE_DB_PATH || path.join(getGlobalDataDir(), "embedding-cache.db"),
       maxAgeHours: 168, // 7 days
     },
   },
@@ -143,8 +143,8 @@ export const defaultConfig: ServerConfig = {
 
   compression: {
     defaultStrategy: "code_structure",
-    minTokensForCompression: 100,
-    targetCompressionRatio: 0.7, // 70% reduction
+    minTokensForCompression: Number(process.env.MIN_TOKENS_FOR_COMPRESSION) || 100,
+    targetCompressionRatio: Number(process.env.TARGET_COMPRESSION_RATIO) || 0.7,
     llm: {
       enabled: process.env.RLM_LLM_ENABLED === "true",
       baseUrl: process.env.RLM_LLM_BASE_URL || "https://api.openai.com/v1",
@@ -158,13 +158,13 @@ export const defaultConfig: ServerConfig = {
   },
 
   rateLimit: {
-    requestsPerMinute: 60,
-    tokensPerMinute: 100000,
+    requestsPerMinute: Number(process.env.REQUESTS_PER_MINUTE) || 60,
+    tokensPerMinute: Number(process.env.TOKENS_PER_MINUTE) || 100000,
   },
 
   security: {
-    maxInputLength: 100000,
-    sanitizeInputs: true,
+    maxInputLength: Number(process.env.MAX_INPUT_LENGTH) || 100000,
+    sanitizeInputs: process.env.SANITIZE_INPUTS !== "false",
     maxIndexSize: 100000, // max files to index
     maxFileSize: 1024 * 1024, // 1MB per file
     allowedExtensions: [
@@ -192,6 +192,7 @@ export const defaultConfig: ServerConfig = {
       "build/**",
       ".next/**",
       "coverage/**",
+      "**/generated/**",
       "*.min.js",
       "*.min.css",
     ],

--- a/scripts/setup-local-first.sh
+++ b/scripts/setup-local-first.sh
@@ -115,7 +115,7 @@ echo -e "  Choose your database backend:"
 echo -e "    ${BLUE}1)${NC} SQLite (default, zero-config, local-first)"
 echo -e "    ${BLUE}2)${NC} PostgreSQL + pgvector (better performance for large datasets)"
 echo ""
-read -p "  Enter your choice [1]: " DB_CHOICE
+read -rp "  Enter your choice [1]: " DB_CHOICE </>/dev/tty || true
 DB_CHOICE=${DB_CHOICE:-1}
 
 USE_POSTGRES=false
@@ -179,7 +179,7 @@ if [ "$DB_CHOICE" = "2" ]; then
         echo -e "  ${GREEN}✓${NC} Database URL: ${DATABASE_URL}"
     else
         echo -e "  ${YELLOW}⚠${NC} Docker not found. Please provide PostgreSQL connection URL:"
-        read -p "  DATABASE_URL: " DATABASE_URL
+        read -rp "  DATABASE_URL: " DATABASE_URL </>/dev/tty || true
         
         if [ -z "$DATABASE_URL" ]; then
             echo -e "  ${RED}✗${NC} No DATABASE_URL provided. Falling back to SQLite."

--- a/scripts/setup-local-first.sh
+++ b/scripts/setup-local-first.sh
@@ -115,7 +115,7 @@ echo -e "  Choose your database backend:"
 echo -e "    ${BLUE}1)${NC} SQLite (default, zero-config, local-first)"
 echo -e "    ${BLUE}2)${NC} PostgreSQL + pgvector (better performance for large datasets)"
 echo ""
-read -rp "  Enter your choice [1]: " DB_CHOICE </>/dev/tty || true
+read -rp "  Enter your choice [1]: " DB_CHOICE </dev/tty || true
 DB_CHOICE=${DB_CHOICE:-1}
 
 USE_POSTGRES=false
@@ -179,7 +179,7 @@ if [ "$DB_CHOICE" = "2" ]; then
         echo -e "  ${GREEN}✓${NC} Database URL: ${DATABASE_URL}"
     else
         echo -e "  ${YELLOW}⚠${NC} Docker not found. Please provide PostgreSQL connection URL:"
-        read -rp "  DATABASE_URL: " DATABASE_URL </>/dev/tty || true
+        read -rp "  DATABASE_URL: " DATABASE_URL </dev/tty || true
         
         if [ -z "$DATABASE_URL" ]; then
             echo -e "  ${RED}✗${NC} No DATABASE_URL provided. Falling back to SQLite."

--- a/scripts/tests/test-setup-wizard-db-selection.sh
+++ b/scripts/tests/test-setup-wizard-db-selection.sh
@@ -148,19 +148,19 @@ echo "Functional: fixed snippet survives piped/EOF stdin"
 FIXED_SNIPPET='
 set -e
 DB_CHOICE=""
-read -rp "" DB_CHOICE </>/dev/tty || true
+read -rp "" DB_CHOICE </dev/tty || true
 DB_CHOICE=${DB_CHOICE:-1}
 echo "DB_CHOICE=$DB_CHOICE"
 '
 assert_exit_zero \
-    "fixed read with </>/dev/tty || true exits 0 on EOF stdin" \
+    "fixed read with </dev/tty || true exits 0 on EOF stdin" \
     bash -c "$FIXED_SNIPPET"
 
 # Test 8: DB_CHOICE defaults to "1" when no input is provided (EOF stdin)
 RESULT=$(bash -c '
 set -e
 DB_CHOICE=""
-read -rp "" DB_CHOICE </>/dev/tty || true
+read -rp "" DB_CHOICE </dev/tty || true
 DB_CHOICE=${DB_CHOICE:-1}
 echo "$DB_CHOICE"
 ' < /dev/null 2>/dev/null || echo "ERROR")
@@ -170,18 +170,18 @@ assert_eq "DB_CHOICE defaults to '1' on EOF stdin" "$RESULT" "1"
 DATABASE_URL_SNIPPET='
 set -e
 DATABASE_URL=""
-read -rp "" DATABASE_URL </>/dev/tty || true
+read -rp "" DATABASE_URL </dev/tty || true
 echo "DATABASE_URL=${DATABASE_URL}"
 '
 assert_exit_zero \
-    "DATABASE_URL prompt with </>/dev/tty || true exits 0 on EOF stdin" \
+    "DATABASE_URL prompt with </dev/tty || true exits 0 on EOF stdin" \
     bash -c "$DATABASE_URL_SNIPPET"
 
 # Test 10: DATABASE_URL is empty (not crashing) when stdin is piped
 URL_RESULT=$(bash -c '
 set -e
 DATABASE_URL=""
-read -rp "" DATABASE_URL </>/dev/tty || true
+read -rp "" DATABASE_URL </dev/tty || true
 echo "$DATABASE_URL"
 ' < /dev/null 2>/dev/null || echo "ERROR")
 assert_eq "DATABASE_URL is empty string on EOF stdin (no crash)" "$URL_RESULT" ""

--- a/scripts/tests/test-setup-wizard-db-selection.sh
+++ b/scripts/tests/test-setup-wizard-db-selection.sh
@@ -1,0 +1,207 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+SETUP_SCRIPT="${PROJECT_ROOT}/scripts/setup-local-first.sh"
+
+# ── Colours ───────────────────────────────────────────────────
+GREEN='\033[0;32m'; RED='\033[0;31m'; BOLD='\033[1m'; NC='\033[0m'
+
+# ── Counters ──────────────────────────────────────────────────
+PASS=0
+FAIL=0
+ERRORS=()
+
+ok()   { echo -e "  ${GREEN}✓${NC} $*"; }
+fail() { echo -e "  ${RED}✗${NC} $*"; }
+
+# assert_eq LABEL ACTUAL EXPECTED
+assert_eq() {
+    local label="$1" actual="$2" expected="$3"
+    if [ "$actual" = "$expected" ]; then
+        ok "$label"
+        PASS=$((PASS + 1))
+    else
+        fail "$label  →  got='${actual}'  want='${expected}'"
+        FAIL=$((FAIL + 1))
+        ERRORS+=("$label")
+    fi
+}
+
+# assert_exit_zero LABEL CMD...
+assert_exit_zero() {
+    local label="$1"; shift
+    local exit_code=0
+    "$@" >/dev/null 2>&1 || exit_code=$?
+    if [ "$exit_code" -eq 0 ]; then
+        ok "$label"
+        PASS=$((PASS + 1))
+    else
+        fail "$label  (expected exit 0, got ${exit_code})"
+        FAIL=$((FAIL + 1))
+        ERRORS+=("$label")
+    fi
+}
+
+# assert_exit_nonzero LABEL CMD...
+assert_exit_nonzero() {
+    local label="$1"; shift
+    local exit_code=0
+    "$@" >/dev/null 2>&1 || exit_code=$?
+    if [ "$exit_code" -ne 0 ]; then
+        ok "$label"
+        PASS=$((PASS + 1))
+    else
+        fail "$label  (expected non-zero exit, got 0)"
+        FAIL=$((FAIL + 1))
+        ERRORS+=("$label")
+    fi
+}
+
+# ================================================================
+echo ""
+echo -e "${BOLD}Setup Wizard DB Selection — Tests (Issue #24)${NC}"
+echo "  script: ${SETUP_SCRIPT}"
+echo ""
+
+# ── Static analysis ───────────────────────────────────────────
+
+echo "Static analysis: source contains the fix"
+
+# Test 1: main DB choice read uses /dev/tty redirect
+DB_CHOICE_READ=$(grep -n 'read.*DB_CHOICE' "$SETUP_SCRIPT" || true)
+if echo "$DB_CHOICE_READ" | grep -q '/dev/tty'; then
+    ok "DB_CHOICE read redirects stdin from /dev/tty"
+    PASS=$((PASS + 1))
+else
+    fail "DB_CHOICE read is missing /dev/tty redirect — original bug not fixed"
+    FAIL=$((FAIL + 1))
+    ERRORS+=("DB_CHOICE read redirects stdin from /dev/tty")
+fi
+
+# Test 2: main DB choice read has || true guard
+if echo "$DB_CHOICE_READ" | grep -q '|| true'; then
+    ok "DB_CHOICE read has '|| true' guard against set -e"
+    PASS=$((PASS + 1))
+else
+    fail "DB_CHOICE read is missing '|| true' — set -e can still trigger on EOF"
+    FAIL=$((FAIL + 1))
+    ERRORS+=("DB_CHOICE read has '|| true' guard against set -e")
+fi
+
+# Test 3: DATABASE_URL prompt read uses /dev/tty redirect
+DATABASE_URL_READ=$(grep -n 'read.*DATABASE_URL' "$SETUP_SCRIPT" || true)
+if echo "$DATABASE_URL_READ" | grep -q '/dev/tty'; then
+    ok "DATABASE_URL read redirects stdin from /dev/tty"
+    PASS=$((PASS + 1))
+else
+    fail "DATABASE_URL read is missing /dev/tty redirect"
+    FAIL=$((FAIL + 1))
+    ERRORS+=("DATABASE_URL read redirects stdin from /dev/tty")
+fi
+
+# Test 4: DATABASE_URL read has || true guard
+if echo "$DATABASE_URL_READ" | grep -q '|| true'; then
+    ok "DATABASE_URL read has '|| true' guard against set -e"
+    PASS=$((PASS + 1))
+else
+    fail "DATABASE_URL read is missing '|| true'"
+    FAIL=$((FAIL + 1))
+    ERRORS+=("DATABASE_URL read has '|| true' guard against set -e")
+fi
+
+# Test 5: no bare 'read -p' without /dev/tty remains in the DB selection section
+BARE_READS=$(grep -n 'read -p\b' "$SETUP_SCRIPT" | grep -v '#' || true)
+if [ -z "$BARE_READS" ]; then
+    ok "no bare 'read -p' (without /dev/tty) remains in the script"
+    PASS=$((PASS + 1))
+else
+    fail "found bare 'read -p' calls that may break in piped mode: ${BARE_READS}"
+    FAIL=$((FAIL + 1))
+    ERRORS+=("no bare 'read -p' without /dev/tty remains in the script")
+fi
+
+# ── Functional: regression — old broken snippet ───────────────
+
+echo ""
+echo "Functional: demonstrate original bug (plain read -p with set -e)"
+
+# Test 6: REGRESSION — old plain read exits non-zero on EOF stdin (the original bug)
+OLD_SNIPPET='
+set -e
+DB_CHOICE=""
+read -p "" DB_CHOICE
+DB_CHOICE=${DB_CHOICE:-1}
+echo "DB_CHOICE=$DB_CHOICE"
+'
+assert_exit_nonzero \
+    "plain 'read -p' with set -e exits non-zero on EOF (original bug reproduced)" \
+    bash -c "$OLD_SNIPPET"
+
+# ── Functional: fixed snippet ──────────────────────────────────
+
+echo ""
+echo "Functional: fixed snippet survives piped/EOF stdin"
+
+# Test 7: fixed read with /dev/tty + || true exits 0 even when stdin is EOF
+FIXED_SNIPPET='
+set -e
+DB_CHOICE=""
+read -rp "" DB_CHOICE </>/dev/tty || true
+DB_CHOICE=${DB_CHOICE:-1}
+echo "DB_CHOICE=$DB_CHOICE"
+'
+assert_exit_zero \
+    "fixed read with </>/dev/tty || true exits 0 on EOF stdin" \
+    bash -c "$FIXED_SNIPPET"
+
+# Test 8: DB_CHOICE defaults to "1" when no input is provided (EOF stdin)
+RESULT=$(bash -c '
+set -e
+DB_CHOICE=""
+read -rp "" DB_CHOICE </>/dev/tty || true
+DB_CHOICE=${DB_CHOICE:-1}
+echo "$DB_CHOICE"
+' < /dev/null 2>/dev/null || echo "ERROR")
+assert_eq "DB_CHOICE defaults to '1' on EOF stdin" "$RESULT" "1"
+
+# Test 9: DATABASE_URL prompt also exits 0 on EOF stdin
+DATABASE_URL_SNIPPET='
+set -e
+DATABASE_URL=""
+read -rp "" DATABASE_URL </>/dev/tty || true
+echo "DATABASE_URL=${DATABASE_URL}"
+'
+assert_exit_zero \
+    "DATABASE_URL prompt with </>/dev/tty || true exits 0 on EOF stdin" \
+    bash -c "$DATABASE_URL_SNIPPET"
+
+# Test 10: DATABASE_URL is empty (not crashing) when stdin is piped
+URL_RESULT=$(bash -c '
+set -e
+DATABASE_URL=""
+read -rp "" DATABASE_URL </>/dev/tty || true
+echo "$DATABASE_URL"
+' < /dev/null 2>/dev/null || echo "ERROR")
+assert_eq "DATABASE_URL is empty string on EOF stdin (no crash)" "$URL_RESULT" ""
+
+# ── Summary ───────────────────────────────────────────────────
+
+echo ""
+echo -e "${BOLD}────────────────────────────────────────${NC}"
+TOTAL=$((PASS + FAIL))
+echo -e "  Results: ${GREEN}${PASS}${NC} passed, ${RED}${FAIL}${NC} failed  (${TOTAL} total)"
+
+if [ ${#ERRORS[@]} -gt 0 ]; then
+    echo ""
+    echo -e "  ${RED}Failed tests:${NC}"
+    for e in "${ERRORS[@]}"; do
+        echo "    - $e"
+    done
+    echo ""
+    exit 1
+fi
+
+echo ""
+exit 0


### PR DESCRIPTION
Summary                                                         

  - Embeddings: novos providers Vercel AI Gateway, LiteLLM e custom OpenAI-compatible; limite maxChars por modelo resolve truncação silenciosa de contexto                                                                                                                    
  - Chunker: reescrita completa do code chunker com detecção de boundaries em duas fases (depth tracking + regex); cap maxChunkChars para nunca exceder o limite do provider; Markdown sem headings cai para fixed-chunking; testes e benchmarks excluídos dos defaults de
  busca                                                                                                                                                                                                                                                                       
  - Postgres vector store: tabela vector_documents_1536d; HNSW efConstruction 128 (recomendação pgvector); inserts em sub-batches de 8 com fallback per-document; detecção de orphaned chunks ao inicializar
  - Hooks de busca: SearchSessionHook persiste memória de sessão após cada search; CoRetrievalHook reforça arestas no grafo de memória entre resultados co-ocorrentes                                                                                                         
  - project_map: endpoint GET /api/v1/workspace/:id/map + ferramenta MCP th0th_project_map — view agregada de stats, arquivos centrais (PageRank), símbolos por kind, arquivos por linguagem                                                                                  
  - Refactor: RelationExtractor desacoplado do SQLite; adapters Prisma injetáveis (testáveis); config de cache/rate-limit/segurança via env vars                                                                                                                              
                                                                                                                                                                                                                                                                              
  Test plan                                                                                                                                                                                                                                                                   
                                                                                                                                                                                                                                                                              
  - bun test passes em packages/core (unit tests de hooks, chunker, prisma-client-fallback)                                                                                                                                                                                   
  - GET /api/v1/workspace/:id/map retorna stats corretos após indexação
  - Trocar EMBEDDING_PROVIDER=vercel e verificar embedding + search funcionando                                                                                                                                                                                               
  - Indexar projeto grande e confirmar logs de ETA aparecendo a cada 5s                                                                                                                                                                                                       
  - Verificar warn de orphaned chunks ao trocar provider sem reindexar          