### PR TITLE
fix: zero-vector embedding issues

### DIFF
--- a/packages/core/src/services/embeddings/provider.ts
+++ b/packages/core/src/services/embeddings/provider.ts
@@ -382,7 +382,11 @@ export class AISDKEmbeddingProvider implements EmbeddingProvider {
                   if (embedding.some(v => isNaN(v) || !isFinite(v))) {
                     throw new Error("Invalid embedding response: contains NaN or Infinity values");
                   }
-                  
+
+                  if (embedding.every(v => v === 0)) {
+                    throw new Error("Invalid embedding response: all-zero vector (model returned degenerate embedding)");
+                  }
+
                   return embedding;
                 });
               }
@@ -545,6 +549,11 @@ export class AISDKEmbeddingProvider implements EmbeddingProvider {
                   if (emb.some((v) => isNaN(v) || !isFinite(v))) {
                     throw new Error(
                       "Invalid embedding response: contains NaN or Infinity values",
+                    );
+                  }
+                  if (emb.every((v) => v === 0)) {
+                    throw new Error(
+                      "Invalid embedding response: all-zero vector (model returned degenerate embedding)",
                     );
                   }
                 }

--- a/packages/core/src/services/search/contextual-search-rlm.ts
+++ b/packages/core/src/services/search/contextual-search-rlm.ts
@@ -514,7 +514,7 @@ export class ContextualSearchRLM {
   ): Promise<SearchResult[]> {
     await this.ensureInitialized();
     const maxResults = options.maxResults || 10;
-    const minScore = options.minScore || 0.3;
+    const minScore = options.minScore ?? 0.3;
     const explainScores = options.explainScores || false;
     const includeFilters = options.includeFilters;
     const excludeFilters = options.excludeFilters;


### PR DESCRIPTION
- provider.ts: add all-zero vector check after NaN/Infinity validation (Ollama returns [0,0,...,0] under load instead of erroring, which silently corrupts the index — 56% of chunks in production were zero-vectors)
- contextual-search-rlm.ts: minScore || 0.3 → minScore ?? 0.3 so that callers can explicitly pass minScore:0 to disable the threshold