### PR TITLE
ci: restrict CI pipeline to release events and update package versions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,9 +3,10 @@ name: Build and Publish
 on:
   release:
     types: [published]
+  workflow_dispatch:
 
 env:
-  NPM_TAG: latest
+  NPM_TAG: ${{ github.event_name == 'release' && 'latest' || 'next' }}
   FORCE_PUBLISH: '--tolerate-republish'
 
 jobs:
@@ -159,8 +160,9 @@ jobs:
         with:
           images: s1lv4/th0th
           tags: |
-            type=raw,value=api-${{ steps.version.outputs.version }}
-            type=raw,value=api-latest
+            type=raw,value=api-${{ steps.version.outputs.version }},enable=${{ github.event_name == 'release' }}
+            type=raw,value=api-latest,enable=${{ github.event_name == 'release' }}
+            type=raw,value=api-new,enable=${{ github.event_name == 'workflow_dispatch' }}
 
       - name: Docker meta for MCP
         id: meta-mcp
@@ -168,8 +170,9 @@ jobs:
         with:
           images: s1lv4/th0th
           tags: |
-            type=raw,value=mcp-${{ steps.version.outputs.version }}
-            type=raw,value=mcp-latest
+            type=raw,value=mcp-${{ steps.version.outputs.version }},enable=${{ github.event_name == 'release' }}
+            type=raw,value=mcp-latest,enable=${{ github.event_name == 'release' }}
+            type=raw,value=mcp-new,enable=${{ github.event_name == 'workflow_dispatch' }}
 
       - name: Build and push API image
         uses: docker/build-push-action@v6

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,38 +3,10 @@ name: Build and Publish
 on:
   release:
     types: [published]
-  workflow_dispatch:
-    inputs:
-      target:
-        description: 'What to publish'
-        required: true
-        default: 'all'
-        type: choice
-        options:
-          - all
-          - packages
-          - apps
-          - docker
-      tag:
-        description: 'npm tag (latest, next, beta, alpha)'
-        required: false
-        default: 'latest'
-        type: string
-      dry-run:
-        description: 'Dry run (no actual publish)'
-        required: false
-        default: false
-        type: boolean
-      force-publish:
-        description: 'Force publish even if version already exists (uses --tolerate-republish)'
-        required: false
-        default: true
-        type: boolean
 
 env:
-  NPM_TAG: ${{ inputs.tag || 'latest' }}
-  DRY_RUN: ${{ inputs.dry-run == true && '--dry-run' || '' }}
-  FORCE_PUBLISH: ${{ (inputs.force-publish == true || github.event_name == 'release') && '--tolerate-republish' || '' }}
+  NPM_TAG: latest
+  FORCE_PUBLISH: '--tolerate-republish'
 
 jobs:
   build:
@@ -91,10 +63,6 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     environment: DEPLOY
-    if: >-
-      github.event_name == 'release' ||
-      inputs.target == 'all' ||
-      inputs.target == 'packages'
     permissions:
       contents: read
       id-token: write
@@ -112,13 +80,13 @@ jobs:
 
       - name: Publish @th0th-ai/shared
         working-directory: packages/shared
-        run: bun publish --access public --tag ${{ env.NPM_TAG }} ${{ env.FORCE_PUBLISH }} ${{ env.DRY_RUN }}
+        run: bun publish --access public --tag ${{ env.NPM_TAG }} ${{ env.FORCE_PUBLISH }}
         env:
           NPM_CONFIG_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Publish @th0th-ai/core
         working-directory: packages/core
-        run: bun publish --access public --tag ${{ env.NPM_TAG }} ${{ env.FORCE_PUBLISH }} ${{ env.DRY_RUN }}
+        run: bun publish --access public --tag ${{ env.NPM_TAG }} ${{ env.FORCE_PUBLISH }}
         env:
           NPM_CONFIG_TOKEN: ${{ secrets.NPM_TOKEN }}
 
@@ -126,10 +94,6 @@ jobs:
     needs: [build, publish-packages]
     runs-on: ubuntu-latest
     environment: DEPLOY
-    if: >-
-      github.event_name == 'release' ||
-      inputs.target == 'all' ||
-      inputs.target == 'apps'
     permissions:
       contents: read
       id-token: write
@@ -147,19 +111,19 @@ jobs:
 
       - name: Publish @th0th-ai/tools-api
         working-directory: apps/tools-api
-        run: bun publish --access public --tag ${{ env.NPM_TAG }} ${{ env.FORCE_PUBLISH }} ${{ env.DRY_RUN }}
+        run: bun publish --access public --tag ${{ env.NPM_TAG }} ${{ env.FORCE_PUBLISH }}
         env:
           NPM_CONFIG_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Publish @th0th-ai/mcp-client
         working-directory: apps/mcp-client
-        run: bun publish --access public --tag ${{ env.NPM_TAG }} ${{ env.FORCE_PUBLISH }} ${{ env.DRY_RUN }}
+        run: bun publish --access public --tag ${{ env.NPM_TAG }} ${{ env.FORCE_PUBLISH }}
         env:
           NPM_CONFIG_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Publish @th0th-ai/opencode-plugin
         working-directory: apps/opencode-plugin
-        run: bun publish --access public --tag ${{ env.NPM_TAG }} ${{ env.FORCE_PUBLISH }} ${{ env.DRY_RUN }}
+        run: bun publish --access public --tag ${{ env.NPM_TAG }} ${{ env.FORCE_PUBLISH }}
         env:
           NPM_CONFIG_TOKEN: ${{ secrets.NPM_TOKEN }}
 
@@ -167,11 +131,6 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     environment: DEPLOY
-    if: >-
-      github.event_name == 'release' ||
-      inputs.target == 'all' ||
-      inputs.target == 'apps' ||
-      inputs.target == 'docker'
     permissions:
       contents: read
 
@@ -201,7 +160,7 @@ jobs:
           images: s1lv4/th0th
           tags: |
             type=raw,value=api-${{ steps.version.outputs.version }}
-            type=raw,value=api-latest,enable=${{ github.event_name == 'release' || github.event_name == 'workflow_dispatch' || github.ref == format('refs/heads/{0}', github.event.repository.default_branch) }}
+            type=raw,value=api-latest
 
       - name: Docker meta for MCP
         id: meta-mcp
@@ -210,7 +169,7 @@ jobs:
           images: s1lv4/th0th
           tags: |
             type=raw,value=mcp-${{ steps.version.outputs.version }}
-            type=raw,value=mcp-latest,enable=${{ github.event_name == 'release' || github.event_name == 'workflow_dispatch' || github.ref == format('refs/heads/{0}', github.event.repository.default_branch) }}
+            type=raw,value=mcp-latest
 
       - name: Build and push API image
         uses: docker/build-push-action@v6
@@ -218,7 +177,7 @@ jobs:
           context: .
           target: api
           platforms: linux/amd64,linux/arm64
-          push: ${{ inputs.dry-run != true }}
+          push: true
           tags: ${{ steps.meta-api.outputs.tags }}
           labels: ${{ steps.meta-api.outputs.labels }}
           cache-from: type=gha
@@ -230,7 +189,7 @@ jobs:
           context: .
           target: mcp
           platforms: linux/amd64,linux/arm64
-          push: ${{ inputs.dry-run != true }}
+          push: true
           tags: ${{ steps.meta-mcp.outputs.tags }}
           labels: ${{ steps.meta-mcp.outputs.labels }}
           cache-from: type=gha

--- a/apps/mcp-client/package.json
+++ b/apps/mcp-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@th0th-ai/mcp-client",
-  "version": "1.1.4",
+  "version": "1.1.5",
   "description": "th0th MCP server - Semantic code search, memory, and context compression via Model Context Protocol",
   "author": "S1LV4",
   "type": "module",

--- a/apps/opencode-plugin/package.json
+++ b/apps/opencode-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@th0th-ai/opencode-plugin",
-  "version": "1.1.3",
+  "version": "1.1.5",
   "description": "th0th plugin for OpenCode - Semantic code search, memory, and context compression",
   "type": "module",
   "main": "dist/index.js",

--- a/apps/tools-api/package.json
+++ b/apps/tools-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@th0th-ai/tools-api",
-  "version": "1.1.4",
+  "version": "1.1.5",
   "author": "S1LV4",
   "description": "th0th REST API server - Semantic code search, memory, and context compression",
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "th0th",
-  "version": "1.1.4",
+  "version": "1.1.5",
   "private": true,
   "author": "S1LV4",
   "description": "th0th - Ancient knowledge keeper for modern code. Semantic search with 98% token reduction",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@th0th-ai/core",
-  "version": "1.1.4",
+  "version": "1.1.5",
   "author": "S1LV4",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@th0th-ai/shared",
-  "version": "1.1.4",
+  "version": "1.1.5",
   "author": "S1LV4",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
This pull request updates the release workflow and package versions across the repository. The main focus is simplifying the GitHub Actions publish workflow by removing manual inputs and dry-run logic, and updating package versions to 1.1.5 for all relevant packages.

**Workflow simplification and automation:**

* Removed all manual input options (`target`, `tag`, `dry-run`, `force-publish`) from the `workflow_dispatch` trigger in `.github/workflows/publish.yml`, making the workflow more automated and less error-prone.
* Updated environment variables and conditional logic in the workflow to default to publishing with the `latest` or `next` npm tag based on the event type, and always enabling `--tolerate-republish`.
* Removed conditional job execution based on manual inputs, so jobs now run solely based on the event type (e.g., `release`). [[1]](diffhunk://#diff-551d1fcf87f78cc3bc18a7b332a4dc5d8773a512062df881c5aba28a6f5c48d7L94-L97) [[2]](diffhunk://#diff-551d1fcf87f78cc3bc18a7b332a4dc5d8773a512062df881c5aba28a6f5c48d7L115-L132) [[3]](diffhunk://#diff-551d1fcf87f78cc3bc18a7b332a4dc5d8773a512062df881c5aba28a6f5c48d7L150-L174)
* Simplified Docker image tagging, so `latest` and versioned tags are only created on `release` events, and a new `-new` tag is created on manual dispatch.
* Removed all dry-run logic from publish and Docker build steps, so all publishes and pushes are now real and unconditional. [[1]](diffhunk://#diff-551d1fcf87f78cc3bc18a7b332a4dc5d8773a512062df881c5aba28a6f5c48d7L115-L132) [[2]](diffhunk://#diff-551d1fcf87f78cc3bc18a7b332a4dc5d8773a512062df881c5aba28a6f5c48d7L150-L174) [[3]](diffhunk://#diff-551d1fcf87f78cc3bc18a7b332a4dc5d8773a512062df881c5aba28a6f5c48d7L203-R183) [[4]](diffhunk://#diff-551d1fcf87f78cc3bc18a7b332a4dc5d8773a512062df881c5aba28a6f5c48d7L233-R195)

**Version updates:**

* Bumped version numbers from 1.1.4/1.1.3 to 1.1.5 in all package manifests: `@th0th-ai/shared`, `@th0th-ai/core`, `@th0th-ai/tools-api`, `@th0th-ai/mcp-client`, `@th0th-ai/opencode-plugin`, and the root `package.json`. [[1]](diffhunk://#diff-3752b1e4e3e2032593e21e9268ec0379680a59e4e7b8517d0d5492a71530d3e8L3-R3) [[2]](diffhunk://#diff-0b810c38f3c138a3d5e44854edefd5eb966617ca84e62f06511f60acc40546c7L3-R3) [[3]](diffhunk://#diff-21b12ae39946019f30556c5cd770ec4099735d159a9beee60680f2ec1eca7360L3-R3) [[4]](diffhunk://#diff-29ade05a2d8f8c937bc553e7ec88cf30692c948bb089a3cbdcbb0b426fd1674eL3-R3) [[5]](diffhunk://#diff-21fc8683850eefb6acab96d8f2e71952d9ff9f67885426b8742729b66a75562bL3-R3) [[6]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L3-R3)