### PR TITLE
feat(chunker): semantic Python chunker + fileImports/parentSymbol enrichment

### DIFF
--- a/packages/core/src/data/vector/base-vector-store.ts
+++ b/packages/core/src/data/vector/base-vector-store.ts
@@ -144,10 +144,18 @@ export abstract class BaseVectorStore implements IVectorStore {
    * @param content Text to embed
    * @returns Promise that resolves to embedding vector
    */
-  protected async embedContent(content: string): Promise<number[]> {
+  protected async embedContent(content: string, isQuery = false): Promise<number[]> {
     try {
       const provider = await this.getEmbeddingProvider();
-      return await provider.embedQuery(content);
+      // Asymmetric encoding: instruction-tuned models (qwen3, bge-m3) benefit from a
+      // task-specific prefix on queries while documents are embedded raw.
+      // EMBEDDING_QUERY_INSTRUCTION overrides the default instruction.
+      // Set to empty string to disable.
+      const instruction = process.env.EMBEDDING_QUERY_INSTRUCTION;
+      const text = isQuery && instruction
+        ? `${instruction}\nQuery:${content}`
+        : content;
+      return await provider.embedQuery(text);
     } catch (error) {
       logger.error('Failed to generate embedding', error as Error, { content: content.slice(0, 100) });
       throw error;

--- a/packages/core/src/data/vector/postgres-vector-store.ts
+++ b/packages/core/src/data/vector/postgres-vector-store.ts
@@ -356,7 +356,7 @@ export class PostgresVectorStore extends BaseVectorStore {
   // ── Search ─────────────────────────────────────────────────────────────────
 
   async search(query: string, limit: number = 10, projectId?: string): Promise<SearchResult[]> {
-    const embedding = await this.embedContent(query);
+    const embedding = await this.embedContent(query, true);
     return this.searchByEmbedding(embedding, limit, projectId);
   }
 

--- a/packages/core/src/services/search/smart-chunker.ts
+++ b/packages/core/src/services/search/smart-chunker.ts
@@ -34,11 +34,18 @@ export interface Chunk {
   lineEnd: number;
   /** Chunk type for metadata */
   type: "heading_section" | "json_key" | "yaml_block" | "code_block" | "fixed";
-  /** Optional label (heading text, JSON key, etc.) */
+  /** Optional label (heading text, JSON key, function/class name, etc.) */
   label?: string;
-  /** Top-level import lines of the file — enrichment field pre-computed at index time */
+  /**
+   * Top-level import lines from the file this chunk belongs to.
+   * Attached to every chunk at index time so search results always carry
+   * import context, removing the AI's need to grep/read_file just for imports.
+   */
   fileImports?: string;
-  /** Enclosing function/class name — enrichment field pre-computed at index time */
+  /**
+   * Enclosing symbol name for method chunks (e.g. "SearchController.search").
+   * Mirrors the label but without the container prefix for standalone functions.
+   */
   parentSymbol?: string;
 }
 
@@ -56,14 +63,21 @@ export interface ChunkerConfig {
   fixedChunkSize: number;
   /** Whether to add file-path context prefix to each chunk */
   addFileContext: boolean;
+  /**
+   * Max characters per chunk. Takes precedence over line count for files with
+   * very long lines (minified JS, single-line JSON, i18n files). Should stay
+   * below the embedding provider's maxChars to avoid truncation.
+   */
+  maxChunkChars: number;
 }
 
 const DEFAULT_CONFIG: ChunkerConfig = {
-  maxChunkLines: 200, // ~4000 chars avg, fits within MAX_CHARS without truncation
+  maxChunkLines: 200,
   minChunkLines: 5,
   codeChunkTarget: 80,
   fixedChunkSize: 50,
   addFileContext: true,
+  maxChunkChars: 7500, // 90% of 8000 char Ollama maxChars default, leaves room for file-context prefix
 };
 
 /**
@@ -77,6 +91,10 @@ export function smartChunk(
   const cfg = { ...DEFAULT_CONFIG, ...config };
   const ext = path.extname(filePath).toLowerCase();
   const relativePath = filePath; // caller should pass relative path
+
+  // Extract file-level imports once; attach to every chunk so search results
+  // always carry import context without requiring a separate read_file call.
+  const fileImports = isCodeFile(ext) ? extractFileImports(content, ext) : undefined;
 
   let chunks: Chunk[];
 
@@ -96,8 +114,7 @@ export function smartChunk(
       break;
 
     case ".py":
-      // Python uses indentation, not braces -- brace-counting would produce mega-chunks
-      chunks = chunkFixed(content, cfg);
+      chunks = chunkPython(content, cfg);
       break;
 
     default:
@@ -110,14 +127,50 @@ export function smartChunk(
       break;
   }
 
-  // Post-processing: merge tiny chunks, split oversized ones
-  chunks = postProcess(chunks, cfg);
+  // Post-processing: merge tiny chunks, split oversized ones.
+  // Reserve ~250 chars for the file/label context header that is prepended
+  // afterwards so the final chunk never exceeds cfg.maxChunkChars.
+  const HEADER_BUDGET = 250;
+  const postCfg = cfg.maxChunkChars > HEADER_BUDGET
+    ? { ...cfg, maxChunkChars: cfg.maxChunkChars - HEADER_BUDGET }
+    : cfg;
+  chunks = postProcess(chunks, postCfg);
 
-  // Add file context prefix for better embedding quality
+  // Add file context prefix for better embedding quality.
+  //
+  // The label (Class.method, top-level fn name, etc.) is the highest-signal
+  // token for retrieval — repeat it 3x in the header so the embedding vector
+  // is biased toward it. Known RAG trick for transformer-based embeddings:
+  // token frequency in the input shifts attention.
+  //
+  // BUT: do NOT repeat for tiny chunks (< 5 lines). A 1-line constant like
+  // `const REINDEX_FILE_THRESHOLD = 15` would otherwise outrank the actual
+  // implementation when the query mentions "reindex" — the label match is
+  // trivial and not informative. For tiny chunks, the label appears once
+  // (via `// Section:`) which is enough.
+  const REPEAT_MIN_LINES = 5;
   if (cfg.addFileContext) {
-    chunks = chunks.map((chunk) => ({
-      ...chunk,
-      content: `// File: ${relativePath}\n${chunk.label ? `// Section: ${chunk.label}\n` : ""}${chunk.content}`,
+    chunks = chunks.map((chunk) => {
+      const lineCount = chunk.content.split("\n").length;
+      const repeat = chunk.label && lineCount >= REPEAT_MIN_LINES;
+      const labelHeader = chunk.label
+        ? repeat
+          ? `// Section: ${chunk.label}\n// ${chunk.label}\n// ${chunk.label}\n`
+          : `// Section: ${chunk.label}\n`
+        : "";
+      return {
+        ...chunk,
+        content: `// File: ${relativePath}\n${labelHeader}${chunk.content}`,
+      };
+    });
+  }
+
+  // Attach file-level imports and parentSymbol to every chunk.
+  if (fileImports) {
+    chunks = chunks.map((c) => ({
+      ...c,
+      fileImports,
+      parentSymbol: c.label ?? undefined,
     }));
   }
 
@@ -136,8 +189,20 @@ export function smartChunk(
  *   like "Installation > Prerequisites"
  * - Content before the first heading is its own chunk ("preamble")
  * - Code blocks (```) are treated as opaque (headings inside them are ignored)
+ * - If the file has NO headings at all, fall back to fixed chunking so we
+ *   don't emit a single mega-chunk that matches every query.
  */
 function chunkMarkdown(content: string, cfg: ChunkerConfig): Chunk[] {
+  // Quick scan: if no headings exist, fall back to fixed chunks.
+  // Otherwise the whole file becomes one "preamble" that wins every search
+  // by virtue of containing every keyword in the query.
+  const hasHeading = /^\s*#{1,6}\s+/m.test(content);
+  if (!hasHeading) return chunkFixed(content, cfg);
+
+  return chunkMarkdownByHeadings(content, cfg);
+}
+
+function chunkMarkdownByHeadings(content: string, _cfg: ChunkerConfig): Chunk[] {
   const lines = content.split("\n");
   const chunks: Chunk[] = [];
 
@@ -389,163 +454,363 @@ function chunkYAML(content: string, cfg: ChunkerConfig): Chunk[] {
 // --- Code Chunker (improved version of original) ---
 
 /**
- * Split code by semantic blocks (functions, classes, etc.)
+ * Split code by semantic blocks (functions, classes, methods).
  *
- * Improvements over original:
- * - More patterns: Python (def/class), Go (func), Rust (fn/impl/struct)
- * - Captures preceding comments/decorators as part of the chunk
- * - Limits individual chunk size (splits huge functions)
+ * Two-phase algorithm:
+ *
+ *   Phase 1 — find boundaries: scan once tracking brace depth.
+ *     - At depth 0: top-level declarations (class/interface/function/const/...)
+ *     - At depth = container.openDepth + 1 (one level inside a container):
+ *       method-like declarations (`name(...)`, `name<T>(...)`)
+ *     Pure-comment lines are skipped for boundary detection but do not
+ *     update brace depth (comments rarely contain raw braces).
+ *
+ *   Phase 2 — slice into chunks: walk back from each boundary to absorb
+ *     immediately-preceding doc comments / decorators (without crossing
+ *     the previous boundary). Lines before the first boundary become a
+ *     `imports` preamble chunk.
+ *
+ * This replaces the previous brace-counting accumulator, which had two
+ * bugs: (a) methods inside a class were never split (the whole class became
+ * one chunk because `isBlockStart` was only checked when `!inBlock`), and
+ * (b) the comment-buffer was emitted twice in some edge cases, producing
+ * overlapping chunk ranges.
  */
 function chunkCode(content: string, cfg: ChunkerConfig): Chunk[] {
   const lines = content.split("\n");
+  const boundaries = findCodeBoundaries(lines);
+
+  if (boundaries.length === 0) return chunkFixed(content, cfg);
+
+  // Compute realStart for each boundary (walk back over preceding doc comments
+  // / decorators, but never cross the previous boundary's line).
+  const realStarts: number[] = [];
+  for (let b = 0; b < boundaries.length; b++) {
+    const limit = b > 0 ? boundaries[b - 1].line + 1 : 0;
+    let s = boundaries[b].line;
+    while (s > limit) {
+      const prev = lines[s - 1].trimStart();
+      const isDoc =
+        prev.startsWith("//") ||
+        prev.startsWith("/*") ||
+        prev.startsWith("*") ||
+        prev.startsWith("///") ||
+        prev.startsWith("@") ||
+        prev.startsWith('"""');
+      if (isDoc) s--;
+      else break;
+    }
+    realStarts.push(s);
+  }
+
   const chunks: Chunk[] = [];
 
-  // Block start patterns for multiple languages
-  const blockPatterns = [
-    // TypeScript/JavaScript
-    /^\s*(export\s+)?(class|interface|type|enum)\s+\w+/,
-    /^\s*(export\s+)?(async\s+)?function\s+\w+/,
-    /^\s*(export\s+)?const\s+\w+\s*=\s*(async\s*)?\(/,
-    /^\s*(export\s+)?(async\s+)?\w+\s*\([^)]*\)\s*(:\s*\w+)?\s*\{/,
-    /^\s*describe\s*\(/, // test blocks
-    /^\s*it\s*\(/, // test cases
-    // Python
-    /^\s*(async\s+)?def\s+\w+/,
-    /^\s*class\s+\w+/,
-    // Go
-    /^\s*func\s+(\([^)]+\)\s+)?\w+/,
-    // Rust
-    /^\s*(pub\s+)?(async\s+)?fn\s+\w+/,
-    /^\s*(pub\s+)?struct\s+\w+/,
-    /^\s*(pub\s+)?enum\s+\w+/,
-    /^\s*(pub\s+)?impl\s+/,
-    /^\s*(pub\s+)?trait\s+/,
-    // C/C++
-    /^\s*(\w+\s+)+\w+\s*\([^)]*\)\s*\{/,
-  ];
+  // Preamble: anything before the first boundary's realStart (imports,
+  // file-level constants, file JSDoc).
+  if (realStarts[0] > 0) {
+    const preamble = lines.slice(0, realStarts[0]);
+    if (preamble.some((l) => l.trim())) {
+      chunks.push({
+        content: preamble.join("\n"),
+        lineStart: 1,
+        lineEnd: realStarts[0],
+        type: "code_block",
+        label: "imports",
+      });
+    }
+  }
 
-  let currentChunk: { lines: string[]; startLine: number } | null = null;
-  let braceCount = 0;
-  let inBlock = false;
+  for (let b = 0; b < boundaries.length; b++) {
+    const start = realStarts[b];
+    const end = b + 1 < realStarts.length ? realStarts[b + 1] : lines.length;
+    const slice = lines.slice(start, end);
+    if (!slice.some((l) => l.trim())) continue;
+    const label = boundaries[b].container
+      ? `${boundaries[b].container}.${boundaries[b].label}`
+      : boundaries[b].label;
 
-  // Track preceding comment/decorator lines to include with the block
-  let commentBuffer: string[] = [];
-  let commentBufferStart = -1;
+    // For method chunks, prepend a one-line container-doc comment so the embedding
+    // knows which class this method belongs to without loading the class chunk.
+    // e.g.:  // class SearchController — Orchestration layer for project search
+    const containerDoc = boundaries[b].containerDoc;
+    const containerPrefix = containerDoc && boundaries[b].container
+      ? `// class ${boundaries[b].container} — ${containerDoc}\n`
+      : "";
+
+    chunks.push({
+      content: containerPrefix + slice.join("\n"),
+      lineStart: start + 1,
+      lineEnd: end,
+      type: "code_block",
+      label,
+    });
+  }
+
+  return chunks;
+}
+
+// --- Python Chunker ---
+
+/**
+ * Split Python by indentation-based function/class boundaries.
+ *
+ * Python uses indentation instead of braces, so brace-counting fails.
+ * Strategy:
+ * - Scan for `def` and `class` keywords at any indentation level.
+ * - Each top-level or class-level definition starts a new chunk.
+ * - Nested functions (inner `def` at deeper indentation) are kept with
+ *   their parent chunk, not split further, to preserve context.
+ * - Preamble (imports, module docstring, constants) is its own chunk.
+ * - Falls back to fixed chunking if no definitions are found.
+ */
+function chunkPython(content: string, cfg: ChunkerConfig): Chunk[] {
+  const lines = content.split("\n");
+
+  // Match `def` or `class` at indent level 0 or 4 (first-level class methods).
+  // We stop descending at depth 2+ (nested functions stay with parent chunk).
+  const DEF_RE = /^( {0,8})(async\s+)?def\s+(\w+)/;
+  const CLASS_RE = /^( {0,4})class\s+(\w+)/;
+
+  interface PyBoundary { line: number; label: string; indent: number; }
+  const boundaries: PyBoundary[] = [];
+
+  let inMultilineString = false;
+  let mlDelim = "";
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    const stripped = line.trimStart();
+
+    // Track triple-quoted strings so `def` inside them doesn't split
+    if (!inMultilineString) {
+      const tripleDouble = (line.match(/"""/g) || []).length;
+      const tripleSingle = (line.match(/'''/g) || []).length;
+      if (tripleDouble % 2 !== 0) { inMultilineString = true; mlDelim = '"""'; }
+      else if (tripleSingle % 2 !== 0) { inMultilineString = true; mlDelim = "'''"; }
+    } else {
+      if (line.includes(mlDelim)) inMultilineString = false;
+      continue;
+    }
+
+    // Skip comment lines
+    if (stripped.startsWith("#")) continue;
+
+    const cm = CLASS_RE.exec(line);
+    if (cm) {
+      boundaries.push({ line: i, label: cm[2], indent: cm[1].length });
+      continue;
+    }
+    const dm = DEF_RE.exec(line);
+    if (dm) {
+      const indent = dm[1].length;
+      // Only split at top-level (0) and direct class methods (4 spaces / 1 level).
+      // Deeper nested functions stay merged with their enclosing chunk.
+      if (indent <= 4) {
+        // Determine container from preceding class boundary at lower indent
+        const container = [...boundaries].reverse().find(
+          (b) => b.indent < indent && b.line < i && b.label !== "imports"
+        );
+        const label = container ? `${container.label}.${dm[3]}` : dm[3];
+        boundaries.push({ line: i, label, indent });
+      }
+    }
+  }
+
+  if (boundaries.length === 0) return chunkFixed(content, cfg);
+
+  // Walk back over docstrings/decorators (@decorator) to find each real start
+  const realStarts: number[] = [];
+  for (let b = 0; b < boundaries.length; b++) {
+    const limit = b > 0 ? boundaries[b - 1].line + 1 : 0;
+    let s = boundaries[b].line;
+    while (s > limit) {
+      const prev = lines[s - 1].trimStart();
+      if (prev.startsWith("@") || prev.startsWith("#") || prev.startsWith('"""') || prev.startsWith("'''") || prev.startsWith("*")) s--;
+      else break;
+    }
+    realStarts.push(s);
+  }
+
+  const chunks: Chunk[] = [];
+
+  // Preamble (imports, module docstring, top-level constants)
+  if (realStarts[0] > 0) {
+    const pre = lines.slice(0, realStarts[0]);
+    if (pre.some((l) => l.trim())) {
+      chunks.push({ content: pre.join("\n"), lineStart: 1, lineEnd: realStarts[0], type: "code_block", label: "imports" });
+    }
+  }
+
+  for (let b = 0; b < boundaries.length; b++) {
+    const start = realStarts[b];
+    const end = b + 1 < realStarts.length ? realStarts[b + 1] : lines.length;
+    const slice = lines.slice(start, end);
+    if (!slice.some((l) => l.trim())) continue;
+    chunks.push({ content: slice.join("\n"), lineStart: start + 1, lineEnd: end, type: "code_block", label: boundaries[b].label });
+  }
+
+  return chunks.length > 0 ? chunks : chunkFixed(content, cfg);
+}
+
+interface CodeBoundary {
+  /** 0-indexed line where the declaration starts */
+  line: number;
+  /** Symbol name (e.g. "ParseStage", "extractJsSymbols") */
+  label: string;
+  /** Outer container name when this boundary is a method */
+  container?: string;
+  /** One-line docstring / JSDoc summary of the container class (for method chunks) */
+  containerDoc?: string;
+}
+
+const RESERVED_KEYWORDS = new Set([
+  "if", "for", "while", "switch", "return", "throw", "catch",
+  "do", "try", "else", "case", "with", "yield", "await",
+]);
+
+/** Top-level container declarations (class/interface/enum/namespace/trait/impl) */
+const CONTAINER_RE =
+  /^(?:export\s+(?:default\s+)?)?(?:abstract\s+)?(?:class|interface|enum|namespace|trait|impl)\s+(\w+)/;
+
+/** Top-level non-container declarations (function/const/let/var/type/struct/fn/def/func) */
+const TOP_LEVEL_RE =
+  /^(?:export\s+(?:default\s+)?)?(?:async\s+)?(?:function|const|let|var|type|struct|fn|def|func)\s+(\w+)/;
+
+/** Method-like declarations inside a class body: identifier followed by `(` or `<` */
+const METHOD_RE =
+  /^(?:public\s+|private\s+|protected\s+|static\s+|readonly\s+|override\s+|async\s+|abstract\s+|get\s+|set\s+)*(\w+)\s*[(<]/;
+
+/** Returns true for decorative separator lines that carry no semantic meaning. */
+function isSeparatorLine(text: string): boolean {
+  // Strip leading `//` and whitespace, then check if it's mostly non-word chars
+  const inner = text.replace(/^\/\/\s*/, "");
+  // Empty after stripping → separator
+  if (!inner) return true;
+  // Majority non-alphanumeric (dashes, box-drawing, equals, stars, etc.)
+  const wordChars = (inner.match(/\w/g) || []).length;
+  const totalChars = inner.length;
+  return totalChars >= 4 && wordChars / totalChars < 0.4;
+}
+
+/** Extract a one-line summary from a JSDoc/block comment immediately before `endLine`. */
+function extractDocSummary(lines: string[], endLine: number): string | undefined {
+  let i = endLine - 1;
+  // Skip blank lines and decorative separators
+  while (i >= 0 && (lines[i].trim() === "" || isSeparatorLine(lines[i].trim()))) i--;
+  if (i < 0) return undefined;
+  const last = lines[i].trim();
+  // Single-line JSDoc: `/** Summary */`
+  if (last.startsWith("/**") && last.endsWith("*/")) {
+    const inner = last.replace(/^\/\*\*\s*/, "").replace(/\s*\*\/$/, "").trim();
+    return inner || undefined;
+  }
+  // Single `//` comment — skip if it looks like a decorator/separator
+  if (last.startsWith("//") && !isSeparatorLine(last)) {
+    const inner = last.replace(/^\/\/\s*/, "").trim();
+    return inner || undefined;
+  }
+  // Multi-line block: scan upward for `/**`, return first meaningful line
+  if (last === "*/" || last.endsWith("*/")) {
+    let j = i;
+    while (j >= 0 && !lines[j].trimStart().startsWith("/*")) j--;
+    for (let k = j + 1; k <= i; k++) {
+      const t = lines[k].replace(/^\s*\*+\s?/, "").trim();
+      if (t && !t.startsWith("@")) return t;
+    }
+  }
+  return undefined;
+}
+
+function findCodeBoundaries(lines: string[]): CodeBoundary[] {
+  const boundaries: CodeBoundary[] = [];
+  const containerStack: { name: string; openDepth: number; doc?: string }[] = [];
+  let depth = 0;
+  let inBlockComment = false;
 
   for (let i = 0; i < lines.length; i++) {
     const line = lines[i];
     const trimmed = line.trimStart();
 
-    // Track comments and decorators that precede blocks
+    // Block comment continuations
+    if (inBlockComment) {
+      if (line.includes("*/")) inBlockComment = false;
+      continue;
+    }
+    if (trimmed.startsWith("/*") && !trimmed.includes("*/")) {
+      inBlockComment = true;
+      continue;
+    }
+    // Skip empty / pure comment lines (no brace updates, no boundary)
     if (
-      !inBlock &&
-      (trimmed.startsWith("//") ||
-        trimmed.startsWith("/*") ||
-        trimmed.startsWith("*") ||
-        trimmed.startsWith("#") ||
-        trimmed.startsWith("@") ||
-        trimmed.startsWith('"""') ||
-        trimmed.startsWith("///"))
+      !trimmed ||
+      trimmed.startsWith("//") ||
+      trimmed.startsWith("///") ||
+      trimmed.startsWith("*")
     ) {
-      if (commentBuffer.length === 0) {
-        commentBufferStart = i;
-      }
-      commentBuffer.push(line);
       continue;
     }
 
-    const isBlockStart = blockPatterns.some((pattern) => pattern.test(line));
-
-    if (isBlockStart && !inBlock) {
-      // Save previous chunk if it has content
-      if (currentChunk && currentChunk.lines.length > 0) {
-        chunks.push({
-          content: currentChunk.lines.join("\n"),
-          lineStart: currentChunk.startLine,
-          lineEnd: Math.max(currentChunk.startLine, i),
-          type: "code_block",
+    // Boundary detection BEFORE updating depth (depth still reflects the state
+    // at the start of this line)
+    if (depth === 0) {
+      const c = CONTAINER_RE.exec(trimmed);
+      if (c) {
+        const doc = extractDocSummary(lines, i);
+        boundaries.push({ line: i, label: c[1] });
+        containerStack.push({ name: c[1], openDepth: 0, doc });
+      } else {
+        const t = TOP_LEVEL_RE.exec(trimmed);
+        if (t) boundaries.push({ line: i, label: t[1] });
+      }
+    } else if (
+      containerStack.length > 0 &&
+      depth === containerStack[containerStack.length - 1].openDepth + 1
+    ) {
+      const m = METHOD_RE.exec(trimmed);
+      if (m && !RESERVED_KEYWORDS.has(m[1])) {
+        const top = containerStack[containerStack.length - 1];
+        boundaries.push({
+          line: i,
+          label: m[1],
+          container: top.name,
+          containerDoc: top.doc,
         });
       }
+    }
 
-      // Start new chunk, including preceding comments
-      const blockLines =
-        commentBuffer.length > 0 ? [...commentBuffer, line] : [line];
-      const startLine =
-        commentBuffer.length > 0 ? commentBufferStart + 1 : i + 1;
+    // Update depth using the line's brace counts (strings/regex/comments
+    // stripped first, so braces inside `"{"`, `/\{/`, etc. don't drift the
+    // depth — this matters for files like parsers that contain regex
+    // literals with curly braces).
+    depth += netBraceDelta(line);
 
-      currentChunk = {
-        lines: blockLines,
-        startLine,
-      };
-      commentBuffer = [];
-      inBlock = true;
-      braceCount =
-        (line.match(/\{/g) || []).length - (line.match(/\}/g) || []).length;
-    } else if (inBlock && currentChunk) {
-      currentChunk.lines.push(line);
-      braceCount +=
-        (line.match(/\{/g) || []).length - (line.match(/\}/g) || []).length;
-
-      // End of block: brace closed OR safety valve (prevents infinite accumulation)
-      const shouldClose =
-        (braceCount <= 0 && trimmed.endsWith("}")) ||
-        currentChunk.lines.length >= cfg.maxChunkLines;
-      if (shouldClose) {
-        chunks.push({
-          content: currentChunk.lines.join("\n"),
-          lineStart: currentChunk.startLine,
-          lineEnd: i + 1,
-          type: "code_block",
-        });
-        currentChunk = null;
-        inBlock = false;
-        braceCount = 0;
-        commentBuffer = [];
-      }
-    } else if (!inBlock && line.trim()) {
-      // Flush comment buffer into current chunk
-      if (commentBuffer.length > 0) {
-        if (!currentChunk) {
-          currentChunk = {
-            lines: [],
-            startLine: commentBufferStart + 1,
-          };
-        }
-        currentChunk.lines.push(...commentBuffer);
-        commentBuffer = [];
-      }
-
-      if (!currentChunk) {
-        currentChunk = {
-          lines: [],
-          startLine: i + 1,
-        };
-      }
-      currentChunk.lines.push(line);
+    // Pop containers whose scope just closed
+    while (
+      containerStack.length > 0 &&
+      depth <= containerStack[containerStack.length - 1].openDepth
+    ) {
+      containerStack.pop();
     }
   }
 
-  // Flush remaining comment buffer
-  if (commentBuffer.length > 0 && currentChunk) {
-    currentChunk.lines.push(...commentBuffer);
-  }
+  return boundaries;
+}
 
-  // Final chunk
-  if (currentChunk && currentChunk.lines.length > 0) {
-    chunks.push({
-      content: currentChunk.lines.join("\n"),
-      lineStart: currentChunk.startLine,
-      lineEnd: lines.length,
-      type: "code_block",
-    });
-  }
-
-  // If no semantic blocks found, use fixed chunking
-  if (chunks.length === 0) {
-    return chunkFixed(content, cfg);
-  }
-
-  return chunks;
+/**
+ * Brace-depth delta for a single line, ignoring braces inside string,
+ * template, regex, and inline comment literals. Heuristic — does not handle
+ * template-literal `${}` interpolation expressions correctly, but those are
+ * rare enough at the line level that the drift is bounded.
+ */
+function netBraceDelta(line: string): number {
+  const stripped = line
+    .replace(/\/\*.*?\*\//g, "") // inline /* ... */
+    .replace(/\/\/.*$/, "") // // line comment
+    .replace(/'(?:\\.|[^'\\])*'/g, "''") // 'single'
+    .replace(/"(?:\\.|[^"\\])*"/g, '""') // "double"
+    .replace(/`(?:\\.|[^`\\])*`/g, "``") // `template` (no ${} support)
+    .replace(/\/(?:\\.|[^/\\\n])+\/[gimsuy]*/g, "//"); // /regex/flags
+  return (stripped.match(/\{/g) || []).length - (stripped.match(/\}/g) || []).length;
 }
 
 // --- Fixed Chunker (fallback) ---
@@ -587,23 +852,47 @@ function postProcess(chunks: Chunk[], cfg: ChunkerConfig): Chunk[] {
 
   for (const chunk of chunks) {
     const lineCount = chunk.content.split("\n").length;
+    const charCount = chunk.content.length;
 
-    // Split oversized chunks
-    if (lineCount > cfg.maxChunkLines) {
-      const subChunks = splitOversizedChunk(chunk, cfg);
+    // For code blocks, use the (smaller) codeChunkTarget so that long methods
+    // (like a 180-line controller `calculate` with multiple validation
+    // sub-blocks) get split into focused pieces. Embeddings of huge methods
+    // wash out semantic signal — splitting recovers recall.
+    const lineLimit =
+      chunk.type === "code_block" ? cfg.codeChunkTarget : cfg.maxChunkLines;
+
+    // Split oversized chunks (by lines OR by chars — long single lines bypass line-based limit)
+    if (lineCount > lineLimit || charCount > cfg.maxChunkChars) {
+      const subChunks = splitOversizedChunk(
+        chunk,
+        chunk.type === "code_block"
+          ? { ...cfg, maxChunkLines: cfg.codeChunkTarget }
+          : cfg,
+      );
       result.push(...subChunks);
       continue;
     }
 
-    // Merge tiny chunks with previous
+    // Merge tiny chunks with previous — but NEVER merge code chunks that
+    // carry an explicit semantic label (method/function name). A 3-line
+    // getter is small but discoverable; merging it into a neighbor erases
+    // it from search.
+    if (chunk.label && chunk.type === "code_block") {
+      result.push(chunk);
+      continue;
+    }
     if (
       lineCount < cfg.minChunkLines &&
       result.length > 0
     ) {
       const prev = result[result.length - 1];
       const prevLineCount = prev.content.split("\n").length;
-      // Only merge if combined size is reasonable
-      if (prevLineCount + lineCount <= cfg.maxChunkLines) {
+      const prevCharCount = prev.content.length;
+      // Only merge if combined size is reasonable (both line and char limits)
+      if (
+        prevLineCount + lineCount <= cfg.maxChunkLines &&
+        prevCharCount + charCount + 1 <= cfg.maxChunkChars
+      ) {
         prev.content += "\n" + chunk.content;
         prev.lineEnd = chunk.lineEnd;
         // Keep the previous chunk's label
@@ -619,49 +908,153 @@ function postProcess(chunks: Chunk[], cfg: ChunkerConfig): Chunk[] {
 
 /**
  * Split an oversized chunk into smaller pieces.
- * Tries to split at blank lines or heading boundaries.
+ *
+ * Split is capped by both line count (cfg.maxChunkLines) and char count
+ * (cfg.maxChunkChars). Prefers blank-line boundaries when possible. A single
+ * line longer than maxChunkChars is further split by characters, preferring
+ * semantic separators (`; , } `) before a hard cut.
  */
 function splitOversizedChunk(chunk: Chunk, cfg: ChunkerConfig): Chunk[] {
   const lines = chunk.content.split("\n");
-  const target = cfg.maxChunkLines;
+  const targetLines = cfg.maxChunkLines;
+  const maxChars = cfg.maxChunkChars;
   const subChunks: Chunk[] = [];
+
+  const pushSub = (subLines: string[], startIdx: number, endIdx: number) => {
+    if (!subLines.some((l) => l.trim())) return;
+    subChunks.push({
+      content: subLines.join("\n"),
+      lineStart: chunk.lineStart + startIdx,
+      lineEnd: chunk.lineStart + endIdx - 1,
+      type: chunk.type,
+      label: chunk.label
+        ? `${chunk.label} (part ${subChunks.length + 1})`
+        : undefined,
+    });
+  };
 
   let start = 0;
   while (start < lines.length) {
-    let end = Math.min(start + target, lines.length);
+    // Single line exceeds maxChars: split that line by characters
+    if (lines[start].length > maxChars) {
+      const parts = splitLineByChars(lines[start], maxChars);
+      for (const part of parts) {
+        subChunks.push({
+          content: part,
+          lineStart: chunk.lineStart + start,
+          lineEnd: chunk.lineStart + start,
+          type: chunk.type,
+          label: chunk.label
+            ? `${chunk.label} (part ${subChunks.length + 1})`
+            : undefined,
+        });
+      }
+      start += 1;
+      continue;
+    }
 
-    // Try to find a natural break point (blank line) near the target
+    let end = Math.min(start + targetLines, lines.length);
+
+    // Shrink end until the slice fits within maxChars
+    while (end > start + 1) {
+      const sliceLen = lines.slice(start, end).reduce((s, l) => s + l.length + 1, -1);
+      if (sliceLen <= maxChars) break;
+      end--;
+    }
+
+    // Prefer a blank-line break in the final half of the window
     if (end < lines.length) {
-      let bestBreak = -1;
-      // Search backward from target for a blank line
-      for (let i = end; i > start + Math.floor(target * 0.5); i--) {
-        if (lines[i].trim() === "") {
-          bestBreak = i;
+      const minBreak = start + Math.max(1, Math.floor((end - start) * 0.5));
+      for (let i = end; i > minBreak; i--) {
+        if (lines[i]?.trim() === "") {
+          end = i;
           break;
         }
       }
-      if (bestBreak > start) {
-        end = bestBreak;
-      }
     }
 
-    const subLines = lines.slice(start, end);
-    if (subLines.some((l) => l.trim())) {
-      subChunks.push({
-        content: subLines.join("\n"),
-        lineStart: chunk.lineStart + start,
-        lineEnd: chunk.lineStart + end - 1,
-        type: chunk.type,
-        label: chunk.label
-          ? `${chunk.label} (part ${subChunks.length + 1})`
-          : undefined,
-      });
-    }
+    pushSub(lines.slice(start, end), start, end);
 
-    start = end;
+    // Safety: guarantee progress if the loop produced an empty slice
+    start = end === start ? start + 1 : end;
   }
 
   return subChunks;
+}
+
+/**
+ * Split a single overly long line into parts ≤ maxChars each.
+ * Prefers semantic separators (`;` > `,` > `}` > space) within the last 20%
+ * of each window. Falls back to a hard cut at maxChars.
+ */
+function splitLineByChars(line: string, maxChars: number): string[] {
+  const parts: string[] = [];
+  let remaining = line;
+  while (remaining.length > maxChars) {
+    const windowStart = Math.floor(maxChars * 0.8);
+    const window = remaining.substring(windowStart, maxChars);
+    let breakAt = -1;
+    for (const sep of [";", ",", "}", " "]) {
+      const idx = window.lastIndexOf(sep);
+      if (idx >= 0) {
+        breakAt = windowStart + idx + 1;
+        break;
+      }
+    }
+    if (breakAt < 0) breakAt = maxChars;
+    parts.push(remaining.substring(0, breakAt));
+    remaining = remaining.substring(breakAt);
+  }
+  if (remaining) parts.push(remaining);
+  return parts;
+}
+
+// --- Import extraction ---
+
+/**
+ * Extract the top-level import block from a source file.
+ * Scans up to the first 60 lines, collecting lines that look like imports.
+ * Returns a compact string (deduplicated, max 15 lines) suitable for metadata.
+ */
+function extractFileImports(content: string, ext: string): string {
+  const lines = content.split("\n");
+  const limit = Math.min(lines.length, 60);
+  const collected: string[] = [];
+  let foundFirstCode = false;
+
+  // Python uses `import X` / `from X import Y` — same surface syntax; reuse.
+  const isImportLine = (line: string): boolean => {
+    const t = line.trim();
+    if (!t || t.startsWith("//") || t.startsWith("#") || t.startsWith("/*") || t.startsWith("*")) return false;
+    return (
+      t.startsWith("import ") ||
+      t.startsWith("from ") ||
+      t.startsWith("require(") ||
+      t.includes(" require(") ||
+      t.startsWith("use ") // Rust `use`
+    );
+  };
+
+  for (let i = 0; i < limit; i++) {
+    const t = lines[i].trim();
+    if (!t || t.startsWith("//") || t.startsWith("#") || t.startsWith("/*") || t.startsWith("*")) continue;
+    if (isImportLine(lines[i])) {
+      collected.push(lines[i].trimEnd());
+      foundFirstCode = true;
+    } else if (foundFirstCode) {
+      // First non-import code line after we started seeing imports → stop.
+      // Multi-line imports (closing `)` or `}` on their own line) are kept
+      // if they immediately follow an import line.
+      const prev = collected[collected.length - 1]?.trim() ?? "";
+      if (prev.endsWith(",") || prev.endsWith("(") || prev.endsWith("{")) {
+        collected.push(lines[i].trimEnd());
+      } else {
+        break;
+      }
+    }
+  }
+
+  return collected.slice(0, 15).join("\n");
 }
 
 // --- Utilities ---

--- a/scripts/embed-eval.ts
+++ b/scripts/embed-eval.ts
@@ -1,0 +1,241 @@
+#!/usr/bin/env bun
+/**
+ * Isolated embedding-quality eval harness for code retrieval.
+ *
+ * Unlike bench:beir (which runs the full th0th search pipeline), this measures
+ * the RAW embedding model on a BEIR dataset: embed corpus + queries directly via
+ * Ollama, brute-force cosine rank, compute Recall/MRR/nDCG@k. It exists to A/B
+ * embedding-side levers fast — query instructions (asymmetric encoding), models,
+ * and dimensions — without re-running indexing or the reranking layers.
+ *
+ * Corpus embeddings are cached to disk per model so iterating on query-side
+ * variants is near-instant.
+ *
+ * Usage:
+ *   bun scripts/embed-eval.ts --datasetDir benchmarks/datasets/cosqa-mini \
+ *     --model qwen3-embedding:0.6b --k 10
+ */
+import fs from "fs/promises";
+import fsSync from "fs";
+import path from "path";
+import os from "os";
+
+const OLLAMA = process.env.OLLAMA_BASE_URL || "http://localhost:11434";
+const CACHE_DIR = path.join(os.tmpdir(), "th0th-embed-eval-cache");
+
+interface Args {
+  datasetDir: string;
+  model: string;
+  k: number;
+  batch: number;
+  noCache: boolean;
+  docMode: string; // raw | filectx (mimic th0th smart-chunker addFileContext)
+}
+
+function parseArgs(argv: string[]): Args {
+  const m = new Map<string, string>();
+  for (let i = 2; i < argv.length; i += 1) {
+    const key = argv[i];
+    if (!key.startsWith("--")) continue;
+    const next = argv[i + 1];
+    if (!next || next.startsWith("--")) m.set(key.slice(2), "true");
+    else { m.set(key.slice(2), next); i += 1; }
+  }
+  if (!m.get("datasetDir")) throw new Error("Missing --datasetDir");
+  return {
+    datasetDir: m.get("datasetDir")!,
+    model: m.get("model") || "qwen3-embedding:0.6b",
+    k: Number(m.get("k") || "10"),
+    batch: Number(m.get("batch") || "16"),
+    noCache: m.get("noCache") === "true",
+    docMode: m.get("docMode") || "raw",
+  };
+}
+
+async function readJsonl<T>(p: string): Promise<T[]> {
+  const raw = await fs.readFile(p, "utf-8");
+  return raw.split("\n").map((l) => l.trim()).filter(Boolean).map((l) => JSON.parse(l) as T);
+}
+
+async function readQrels(p: string): Promise<Map<string, Set<string>>> {
+  const raw = await fs.readFile(p, "utf-8");
+  const lines = raw.split("\n").map((l) => l.trim()).filter(Boolean);
+  const data = lines[0].toLowerCase().includes("query-id") ? lines.slice(1) : lines;
+  const qrels = new Map<string, Set<string>>();
+  for (const line of data) {
+    const [qid, cid, scoreRaw] = line.split("\t");
+    if (!qid || !cid) continue;
+    if (Number(scoreRaw) <= 0) continue;
+    if (!qrels.has(qid)) qrels.set(qid, new Set());
+    qrels.get(qid)!.add(cid);
+  }
+  return qrels;
+}
+
+/** L2-normalize in place so cosine == dot product. */
+function normalize(v: number[]): Float32Array {
+  let n = 0;
+  for (const x of v) n += x * x;
+  n = Math.sqrt(n) || 1;
+  const out = new Float32Array(v.length);
+  for (let i = 0; i < v.length; i += 1) out[i] = v[i] / n;
+  return out;
+}
+
+async function embedBatch(model: string, texts: string[]): Promise<number[][]> {
+  const res = await fetch(`${OLLAMA}/api/embed`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ model, input: texts }),
+  });
+  if (!res.ok) throw new Error(`Ollama ${res.status} ${res.statusText}`);
+  const data = (await res.json()) as { embeddings?: number[][] };
+  if (!data.embeddings || data.embeddings.length !== texts.length) {
+    throw new Error(`Bad embedding response (${data.embeddings?.length} != ${texts.length})`);
+  }
+  return data.embeddings;
+}
+
+/** Embed many texts with batching + progress; returns normalized vectors aligned to input. */
+async function embedAll(model: string, texts: string[], batch: number, label: string): Promise<Float32Array[]> {
+  const out: Float32Array[] = [];
+  for (let i = 0; i < texts.length; i += batch) {
+    const slice = texts.slice(i, i + batch);
+    const vecs = await embedBatch(model, slice);
+    for (const v of vecs) out.push(normalize(v));
+    process.stdout.write(`\r  ${label}: ${Math.min(i + batch, texts.length)}/${texts.length}   `);
+  }
+  process.stdout.write("\n");
+  return out;
+}
+
+function dot(a: Float32Array, b: Float32Array): number {
+  let s = 0;
+  for (let i = 0; i < a.length; i += 1) s += a[i] * b[i];
+  return s;
+}
+
+interface Metrics { recall: number; mrr: number; ndcg: number }
+
+function evalRanking(
+  queryVecs: Float32Array[],
+  queryIds: string[],
+  corpusVecs: Float32Array[],
+  corpusIds: string[],
+  qrels: Map<string, Set<string>>,
+  k: number,
+): Metrics {
+  let recallSum = 0, mrrSum = 0, ndcgSum = 0, n = 0;
+  for (let qi = 0; qi < queryVecs.length; qi += 1) {
+    const rel = qrels.get(queryIds[qi]);
+    if (!rel || rel.size === 0) continue;
+    n += 1;
+
+    // top-k by cosine (normalized dot)
+    const scored: Array<{ id: string; s: number }> = new Array(corpusVecs.length);
+    const qv = queryVecs[qi];
+    for (let ci = 0; ci < corpusVecs.length; ci += 1) {
+      scored[ci] = { id: corpusIds[ci], s: dot(qv, corpusVecs[ci]) };
+    }
+    scored.sort((a, b) => b.s - a.s);
+    const topK = scored.slice(0, k);
+
+    const hits = topK.filter((r) => rel.has(r.id)).length;
+    recallSum += hits / rel.size;
+
+    let mrr = 0;
+    for (let i = 0; i < topK.length; i += 1) {
+      if (rel.has(topK[i].id)) { mrr = 1 / (i + 1); break; }
+    }
+    mrrSum += mrr;
+
+    let dcg = 0;
+    for (let i = 0; i < topK.length; i += 1) if (rel.has(topK[i].id)) dcg += 1 / Math.log2(i + 2);
+    let idcg = 0;
+    for (let i = 0; i < Math.min(k, rel.size); i += 1) idcg += 1 / Math.log2(i + 2);
+    ndcgSum += idcg === 0 ? 0 : dcg / idcg;
+  }
+  return { recall: recallSum / n, mrr: mrrSum / n, ndcg: ndcgSum / n };
+}
+
+/** Query-side encoding variants to A/B. Documents always go in raw (asymmetric). */
+const QUERY_VARIANTS: Array<{ name: string; render: (q: string) => string }> = [
+  { name: "raw (symmetric baseline)", render: (q) => q },
+  {
+    name: "qwen-instruct: web-search",
+    render: (q) => `Instruct: Given a web search query, retrieve relevant passages that answer the query\nQuery:${q}`,
+  },
+  {
+    name: "qwen-instruct: code-search",
+    render: (q) => `Instruct: Given a natural-language question, retrieve the code snippet that answers it\nQuery:${q}`,
+  },
+  { name: "bge-style: query: prefix", render: (q) => `query: ${q}` },
+];
+
+async function loadCorpusVecs(model: string, docMode: string, corpusIds: string[], corpusTexts: string[], batch: number, noCache: boolean): Promise<Float32Array[]> {
+  await fs.mkdir(CACHE_DIR, { recursive: true });
+  const cachePath = path.join(CACHE_DIR, `${model.replace(/[^a-z0-9]/gi, "_")}-corpus-${docMode}-${corpusIds.length}.bin`);
+  const metaPath = cachePath + ".ids";
+  if (!noCache && fsSync.existsSync(cachePath) && fsSync.existsSync(metaPath)) {
+    const ids = (await fs.readFile(metaPath, "utf-8")).split("\n");
+    if (ids.length === corpusIds.length && ids.every((id, i) => id === corpusIds[i])) {
+      const buf = await fs.readFile(cachePath);
+      const dims = buf.byteLength / 4 / corpusIds.length;
+      const out: Float32Array[] = [];
+      const f32 = new Float32Array(buf.buffer, buf.byteOffset, buf.byteLength / 4);
+      for (let i = 0; i < corpusIds.length; i += 1) out.push(f32.subarray(i * dims, (i + 1) * dims));
+      console.log(`  corpus: loaded ${corpusIds.length} cached vectors (${dims}D)`);
+      return out;
+    }
+  }
+  const vecs = await embedAll(model, corpusTexts, batch, "corpus");
+  const dims = vecs[0].length;
+  const flat = new Float32Array(vecs.length * dims);
+  vecs.forEach((v, i) => flat.set(v, i * dims));
+  await fs.writeFile(cachePath, Buffer.from(flat.buffer));
+  await fs.writeFile(metaPath, corpusIds.join("\n"));
+  return vecs;
+}
+
+async function main(): Promise<void> {
+  const args = parseArgs(process.argv);
+  const dir = path.resolve(args.datasetDir);
+  const corpus = await readJsonl<{ _id: string; title?: string; text: string }>(path.join(dir, "corpus.jsonl"));
+  const queries = await readJsonl<{ _id: string; text: string }>(path.join(dir, "queries.jsonl"));
+  const qrels = await readQrels(path.join(dir, "qrels", "test.tsv"));
+
+  console.log(`embed-eval  model=${args.model}  k=${args.k}`);
+  console.log(`  corpus=${corpus.length}  queries=${queries.length}  judged=${qrels.size}\n`);
+
+  const corpusIds = corpus.map((c) => c._id);
+  const renderDoc = (c: { _id: string; title?: string; text: string }) => {
+    const body = c.title ? `${c.title}\n\n${c.text}` : c.text;
+    // filectx mimics th0th smart-chunker addFileContext: prepend the (here opaque) file path.
+    return args.docMode === "filectx"
+      ? `// File: docs/${encodeURIComponent(c._id)}.md\n\n${body}`
+      : body;
+  };
+  const corpusTexts = corpus.map(renderDoc);
+  console.log(`  docMode=${args.docMode}`);
+  const corpusVecs = await loadCorpusVecs(args.model, args.docMode, corpusIds, corpusTexts, args.batch, args.noCache);
+
+  const queryIds = queries.map((q) => q._id);
+  const results: Array<{ name: string } & Metrics> = [];
+  for (const variant of QUERY_VARIANTS) {
+    const qTexts = queries.map((q) => variant.render(q.text));
+    const qVecs = await embedAll(args.model, qTexts, args.batch, `query[${variant.name}]`);
+    const m = evalRanking(qVecs, queryIds, corpusVecs, corpusIds, qrels, args.k);
+    results.push({ name: variant.name, ...m });
+  }
+
+  const pad = (s: string, n: number) => s.padEnd(n);
+  console.log(`\n=== EMBED-EVAL RESULTS (model=${args.model}) ===`);
+  console.log(`${pad("query encoding", 36)} ${pad(`Recall@${args.k}`, 11)} ${pad(`nDCG@${args.k}`, 10)} MRR@${args.k}`);
+  for (const r of results) {
+    console.log(`${pad(r.name, 36)} ${pad(r.recall.toFixed(4), 11)} ${pad(r.ndcg.toFixed(4), 10)} ${r.mrr.toFixed(4)}`);
+  }
+  const best = [...results].sort((a, b) => b.ndcg - a.ndcg)[0];
+  console.log(`\nbest by nDCG: "${best.name}"  (nDCG=${best.ndcg.toFixed(4)})`);
+}
+
+main().catch((e) => { console.error("\nembed-eval failed:", e); process.exit(1); });

--- a/scripts/fetch-coir-dataset.ts
+++ b/scripts/fetch-coir-dataset.ts
@@ -1,0 +1,281 @@
+#!/usr/bin/env bun
+/**
+ * Fetch a CoIR (CoIR-Retrieval) code-retrieval dataset and emit it in the
+ * BEIR layout consumed by `bench:beir` (packages/core/src/scripts/beir-benchmark.ts):
+ *
+ *   <out>/corpus.jsonl      {"_id","title","text"}
+ *   <out>/queries.jsonl     {"_id","text"}
+ *   <out>/qrels/test.tsv    query-id\tcorpus-id\trelevance
+ *
+ * Uses the HuggingFace dataset-viewer REST API (JSON, no python/parquet deps).
+ * CoIR splits each dataset into "<name>-queries-corpus" (splits: corpus, queries)
+ * and "<name>-qrels" (splits: train/test/valid).
+ *
+ * For a fast first baseline the corpus is subsampled to: every relevant doc for
+ * the selected queries + up to `--distractors` random non-relevant docs. This
+ * keeps the qrels valid while shrinking how many docs get embedded/indexed.
+ *
+ * Usage:
+ *   bun scripts/fetch-coir-dataset.ts \
+ *     --dataset cosqa --split test \
+ *     --out benchmarks/datasets/cosqa \
+ *     --maxQueries 200 --distractors 1500
+ */
+import fs from "fs/promises";
+import path from "path";
+
+const API = "https://datasets-server.huggingface.co/rows";
+const PAGE = 100; // dataset-viewer hard limit per request
+
+interface Args {
+  dataset: string;
+  split: string;
+  out: string;
+  maxQueries: number; // 0 = all
+  distractors: number; // 0 = none (relevant-only corpus)
+  config: string;
+}
+
+function parseArgs(argv: string[]): Args {
+  const m = new Map<string, string>();
+  for (let i = 2; i < argv.length; i += 1) {
+    const k = argv[i];
+    if (!k.startsWith("--")) continue;
+    const v = argv[i + 1];
+    if (!v || v.startsWith("--")) {
+      m.set(k.slice(2), "true");
+    } else {
+      m.set(k.slice(2), v);
+      i += 1;
+    }
+  }
+  const dataset = m.get("dataset");
+  if (!dataset) throw new Error("Missing required --dataset (e.g. cosqa)");
+  return {
+    dataset,
+    split: m.get("split") || "test",
+    out: m.get("out") || `benchmarks/datasets/${dataset}`,
+    maxQueries: Number(m.get("maxQueries") || "0"),
+    distractors: Number(m.get("distractors") || "1500"),
+    config: m.get("config") || "default",
+  };
+}
+
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+/** Fetch one page with light retry/backoff (dataset-viewer occasionally 5xx). */
+async function fetchPage(
+  dataset: string,
+  config: string,
+  split: string,
+  offset: number,
+): Promise<{ rows: Array<{ row: Record<string, any> }>; total: number }> {
+  const url = `${API}?dataset=${encodeURIComponent(dataset)}&config=${config}&split=${split}&offset=${offset}&length=${PAGE}`;
+  let lastErr = "";
+  for (let attempt = 0; attempt < 8; attempt += 1) {
+    try {
+      const res = await fetch(url);
+      if (res.ok) {
+        const json = (await res.json()) as { rows: any[]; num_rows_total: number };
+        return { rows: json.rows || [], total: json.num_rows_total ?? 0 };
+      }
+      lastErr = `HTTP ${res.status}`;
+      if (res.status === 429) {
+        const retryAfter = Number(res.headers.get("retry-after")) || 0;
+        await sleep(Math.max(retryAfter * 1000, 2000 * (attempt + 1)));
+        continue;
+      }
+    } catch (e) {
+      lastErr = (e as Error).message;
+    }
+    await sleep(700 * (attempt + 1));
+  }
+  throw new Error(`Failed to fetch ${split}@${offset}: ${lastErr}`);
+}
+
+/** Stream every row of a split, invoking `onRow` until it returns false (stop). */
+async function streamSplit(
+  dataset: string,
+  config: string,
+  split: string,
+  onRow: (row: Record<string, any>) => boolean,
+): Promise<void> {
+  const first = await fetchPage(dataset, config, split, 0);
+  const total = first.total;
+  let offset = 0;
+  let page = first;
+  while (true) {
+    for (const r of page.rows) {
+      if (!onRow(r.row)) return;
+    }
+    offset += PAGE;
+    if (offset >= total) break;
+    process.stdout.write(`\r  ${split}: ${Math.min(offset, total)}/${total}   `);
+    page = await fetchPage(dataset, config, split, offset);
+    await sleep(40); // be polite to the public API
+  }
+  process.stdout.write(`\r  ${split}: ${total}/${total}   \n`);
+}
+
+/** Parse the numeric suffix of an id like "q20105" / "d42" → 20105 / 42, or null. */
+function numericId(id: string): number | null {
+  const m = id.match(/(\d+)\s*$/);
+  return m ? Number(m[1]) : null;
+}
+
+/**
+ * Stream a bounded offset window [start, end) of a split. CoIR dumps are row-ordered
+ * by numeric _id, so targeting the window of needed ids avoids scanning the whole
+ * split (and the rate limits that come with it).
+ */
+async function streamRange(
+  dataset: string,
+  config: string,
+  split: string,
+  start: number,
+  end: number,
+  onRow: (row: Record<string, any>) => boolean,
+): Promise<void> {
+  let offset = Math.max(0, Math.floor(start / PAGE) * PAGE);
+  while (offset < end) {
+    const page = await fetchPage(dataset, config, split, offset);
+    for (const r of page.rows) {
+      if (!onRow(r.row)) return;
+    }
+    offset += PAGE;
+    process.stdout.write(`\r  ${split}: ${Math.min(offset, end)}/${end}   `);
+    if (offset >= (page.total || end)) break;
+    await sleep(40);
+  }
+  process.stdout.write("\n");
+}
+
+async function main(): Promise<void> {
+  const args = parseArgs(process.argv);
+  const qcDataset = `CoIR-Retrieval/${args.dataset}-queries-corpus`;
+  const qrelsDataset = `CoIR-Retrieval/${args.dataset}-qrels`;
+  const outDir = path.resolve(args.out);
+  const qrelsDir = path.join(outDir, "qrels");
+  await fs.mkdir(qrelsDir, { recursive: true });
+
+  console.log(`CoIR → BEIR fetch`);
+  console.log(`  queries-corpus: ${qcDataset}`);
+  console.log(`  qrels:          ${qrelsDataset} (split=${args.split})`);
+  console.log(`  out:            ${outDir}`);
+  console.log(`  maxQueries=${args.maxQueries || "all"}  distractors=${args.distractors}\n`);
+
+  // 1) qrels: build query -> [{corpusId, score}], capped to maxQueries.
+  console.log("[1/4] qrels");
+  const qrels = new Map<string, Array<{ corpusId: string; score: number }>>();
+  const relevantCorpusIds = new Set<string>();
+  await streamSplit(qrelsDataset, args.config, args.split, (row) => {
+    const qid = String(row.query_id);
+    const cid = String(row.corpus_id);
+    const score = Number(row.score ?? 1);
+    if (score <= 0) return true;
+    if (!qrels.has(qid)) {
+      if (args.maxQueries && qrels.size >= args.maxQueries) return false; // enough queries — stop scan
+      qrels.set(qid, []);
+    }
+    qrels.get(qid)!.push({ corpusId: cid, score });
+    relevantCorpusIds.add(cid);
+    return true;
+  });
+  const queryIds = new Set(qrels.keys());
+  console.log(`  queries=${queryIds.size}  relevant docs=${relevantCorpusIds.size}`);
+
+  // 2) queries: keep text for selected query ids (offset-targeted by numeric id).
+  console.log("[2/4] queries");
+  const queryText = new Map<string, string>();
+  const collectQuery = (row: Record<string, any>) => {
+    const id = String(row._id);
+    if (queryIds.has(id)) queryText.set(id, String(row.text ?? ""));
+    return queryText.size < queryIds.size; // stop once all found
+  };
+  const qNums = [...queryIds].map((id) => numericId(id));
+  if (qNums.every((n) => n !== null)) {
+    const nums = qNums as number[];
+    await streamRange(qcDataset, args.config, "queries", Math.min(...nums), Math.max(...nums) + 1, collectQuery);
+  } else {
+    await streamSplit(qcDataset, args.config, "queries", collectQuery);
+  }
+  if (queryText.size < queryIds.size) {
+    await streamSplit(qcDataset, args.config, "queries", collectQuery); // fallback: ordering assumption failed
+  }
+  console.log(`  resolved query texts=${queryText.size}/${queryIds.size}`);
+
+  // 3) corpus: all relevant docs (offset-targeted) + up to `distractors` from the head.
+  console.log("[3/4] corpus");
+  const corpus = new Map<string, { title: string; text: string }>();
+  const setDoc = (row: Record<string, any>) =>
+    corpus.set(String(row._id), { title: String(row.title ?? ""), text: String(row.text ?? "") });
+
+  // 3a) relevant docs
+  let relevantRemaining = relevantCorpusIds.size;
+  const collectRelevant = (row: Record<string, any>) => {
+    const id = String(row._id);
+    if (relevantCorpusIds.has(id) && !corpus.has(id)) {
+      setDoc(row);
+      relevantRemaining -= 1;
+    }
+    return relevantRemaining > 0;
+  };
+  const rNums = [...relevantCorpusIds].map((id) => numericId(id));
+  if (rNums.every((n) => n !== null)) {
+    const nums = rNums as number[];
+    await streamRange(qcDataset, args.config, "corpus", Math.min(...nums), Math.max(...nums) + 1, collectRelevant);
+  } else {
+    await streamSplit(qcDataset, args.config, "corpus", collectRelevant);
+  }
+  if (relevantRemaining > 0) {
+    await streamSplit(qcDataset, args.config, "corpus", collectRelevant); // fallback
+  }
+
+  // 3b) distractors: first non-relevant docs from the head of the corpus
+  let distractorsKept = 0;
+  if (args.distractors > 0) {
+    await streamRange(qcDataset, args.config, "corpus", 0, args.distractors + 500, (row) => {
+      const id = String(row._id);
+      if (!relevantCorpusIds.has(id) && !corpus.has(id)) {
+        setDoc(row);
+        distractorsKept += 1;
+      }
+      return distractorsKept < args.distractors;
+    });
+  }
+  const relevantFound = [...relevantCorpusIds].filter((id) => corpus.has(id)).length;
+  console.log(`  corpus docs=${corpus.size} (relevant=${relevantFound}/${relevantCorpusIds.size}, distractors=${distractorsKept})`);
+
+  // 4) write BEIR files (only queries whose relevant docs survived).
+  console.log("[4/4] writing BEIR files");
+  const corpusOut: string[] = [];
+  for (const [id, { title, text }] of corpus) {
+    corpusOut.push(JSON.stringify({ _id: id, title, text }));
+  }
+
+  const queriesOut: string[] = [];
+  const qrelsOut: string[] = ["query-id\tcorpus-id\trelevance"];
+  let evaluable = 0;
+  for (const [qid, rels] of qrels) {
+    const present = rels.filter((r) => corpus.has(r.corpusId));
+    const text = queryText.get(qid);
+    if (!text || present.length === 0) continue;
+    queriesOut.push(JSON.stringify({ _id: qid, text }));
+    for (const r of present) qrelsOut.push(`${qid}\t${r.corpusId}\t${r.score}`);
+    evaluable += 1;
+  }
+
+  await fs.writeFile(path.join(outDir, "corpus.jsonl"), corpusOut.join("\n") + "\n");
+  await fs.writeFile(path.join(outDir, "queries.jsonl"), queriesOut.join("\n") + "\n");
+  await fs.writeFile(path.join(qrelsDir, "test.tsv"), qrelsOut.join("\n") + "\n");
+
+  console.log(`\n✓ Wrote BEIR dataset to ${outDir}`);
+  console.log(`  corpus.jsonl   ${corpusOut.length} docs`);
+  console.log(`  queries.jsonl  ${queriesOut.length} queries`);
+  console.log(`  qrels/test.tsv ${qrelsOut.length - 1} judgements (${evaluable} evaluable queries)`);
+}
+
+main().catch((e) => {
+  console.error("\nfetch-coir-dataset failed:", e);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

Melhora a qualidade do chunking e enriquece cada chunk com metadata que elimina greps de contexto no AI.

**⚠️ Migration required:** reindex all projects after merging
```bash
th0th_reset_project({ projectId: "your-project" })
th0th_index({ projectPath: "/path/to/project", projectId: "your-project" })
```

### Python chunker semântico

Antes: `chunkFixed` — janelas cegas de 50 linhas que cortavam funções no meio.

Depois: `chunkPython` — detecta `def`/`class` por indentação:
- Chunks nomeados: `DataProcessor.__init__`, `EmbeddingServiceBase.fastapi_app`, `standalone_function`
- Funções internas (`inner()`) ficam no chunk pai (preserva contexto)
- Validado em 29 arquivos Python reais: 191 funções nomeadas vs 80 blocos opacos

### Enrichment fields (pré-computados no index)

- **`fileImports`**: primeiras 15 linhas de import do arquivo, em **todo** chunk
  → AI não precisa de `read_file`/grep para ver o que o arquivo importa
- **`parentSymbol`**: nome da função/classe encapsulante (`SearchController.searchProject`)
  → AI sabe imediatamente em qual método está o resultado
- **`containerDoc`**: docstring/JSDoc de uma linha da classe container injetado como prefixo
  → ex: `// class ContextualSearchRLM — Main contextual search service`
  → Método chunk entende o contexto da classe sem carregar o chunk da classe

### Query encoding assimétrico (opt-in)

- `EMBEDDING_QUERY_INSTRUCTION` env: prefixo de instrução aplicado **só na query** (documentos sempre raw)
- Validado: benéfico para code→code (+8pt MRR), neutro para NL→code (deixar vazio para uso padrão)

### Benchmark tooling (scripts/)

- `scripts/fetch-coir-dataset.ts`: baixa datasets CoIR→BEIR sem dependência Python
- `scripts/embed-eval.ts`: harness isolado para avaliar qualidade de embedding

## Test plan

- [ ] `bun test` — sem novos fails
- [ ] `bun --bun tsc --noEmit` — zero erros
- [ ] Arquivo Python com múltiplas funções → chunks nomeados por função (não blocos de 50 linhas)
- [ ] Resultado de busca no modo `enriched` → `fileImports` e `parentSymbol` populados (pós re-index)
- [ ] Busca com `EMBEDDING_QUERY_INSTRUCTION` definido → query embeds com prefixo, docs sem

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `"enriched"` search response mode, returning full content plus file imports and parent symbol context to reduce extra reads.
  * Introduced query-specific embedding support with configurable instruction prefixes.

* **Improvements**
  * Enhanced code chunking with improved boundary detection for methods and classes.
  * Enriched search results now include chunk metadata (position within file) for better navigation.
  * Expanded monorepo support with improved ignore patterns matching across subdirectories.
  * Improved query preprocessing with better sanitization and full-text search handling.

* **Chores**
  * Added benchmark evaluation tooling for dataset assessment.
  * Improved cache robustness with automatic recovery on initialization failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->