### PR TITLE
feat(mcp): complete MCP coverage (21 tools) + SKILL.md v3

### DIFF
--- a/apps/mcp-client/src/tool-definitions.ts
+++ b/apps/mcp-client/src/tool-definitions.ts
@@ -454,6 +454,56 @@ export const TOOL_DEFINITIONS: ToolDefinition[] = [
     },
   },
 
+  // ── File read ────────────────────────────────────────────────────────────
+
+  {
+    name: "th0th_read_file",
+    description:
+      "Read a specific file (or line range) with automatic compression, import extraction, and symbol metadata. " +
+      "Use this instead of the native Read tool or Bash grep when you have a filePath and lineStart/lineEnd from a th0th_search result — " +
+      "returns structured imports[], symbol definitions/references, and optionally compressed content. " +
+      "Pass lineStart/lineEnd to read only the relevant section (saves tokens).",
+    apiEndpoint: "/api/v1/file/read",
+    apiMethod: "POST",
+    inputSchema: {
+      type: "object",
+      properties: {
+        filePath: {
+          type: "string",
+          description: "File path (absolute, or relative to project root)",
+        },
+        projectId: {
+          type: "string",
+          description: "Project ID for symbol metadata (optional but recommended)",
+        },
+        lineStart: {
+          type: "number",
+          description: "First line to read, 1-indexed (default: start of file). Subtract 5-10 from search result lineStart for context.",
+        },
+        lineEnd: {
+          type: "number",
+          description: "Last line to read, 1-indexed (default: end of file). Add 5-10 to search result lineEnd for context.",
+        },
+        compress: {
+          type: "boolean",
+          description: "Auto-compress content > 100 lines to reduce tokens (default: true)",
+          default: true,
+        },
+        includeSymbols: {
+          type: "boolean",
+          description: "Include symbol definitions and references in the read range (default: true)",
+          default: true,
+        },
+        includeImports: {
+          type: "boolean",
+          description: "Extract and return the file's import statements (default: true)",
+          default: true,
+        },
+      },
+      required: ["filePath"],
+    },
+  },
+
   // ── Project reset ───────────────────────────────────────────────────────
 
   {
@@ -487,6 +537,143 @@ export const TOOL_DEFINITIONS: ToolDefinition[] = [
         },
       },
       required: ["projectId"],
+    },
+  },
+
+  // ── Synapse session management ───────────────────────────────────────────
+
+  {
+    name: "th0th_synapse_session",
+    description:
+      "Create (or resume) a Synapse cognitive session for a multi-step task. " +
+      "Returns a sessionId to pass as `synapseSessionId` on every subsequent th0th_search call. " +
+      "The session activates task alignment, agent affinity, the working-memory buffer, " +
+      "chain inhibition, and the adaptive confidence gate. " +
+      "Name sessions by intent: 'debug-auth', 'feature-payment', 'refactor-search'.",
+    apiEndpoint: "/api/v1/synapse/session",
+    apiMethod: "POST",
+    inputSchema: {
+      type: "object",
+      properties: {
+        sessionId: {
+          type: "string",
+          description: "Reuse an existing session ID (omit to auto-generate). Use same ID across all turns of a task.",
+        },
+        agentId: { type: "string", description: "Stable agent identifier (e.g. 'claude-code')", default: "claude-code" },
+        workspaceId: { type: "string", description: "Project ID this session is scoped to" },
+        taskContext: { type: "string", description: "One-sentence description of the current task (used for task alignment scoring)" },
+        ttlMs: { type: "number", description: "Session TTL in ms (default: 15 min)", default: 900000 },
+      },
+      required: [],
+    },
+  },
+
+  {
+    name: "th0th_synapse_prime",
+    description:
+      "Seed the Synapse working-memory buffer with known-relevant results before searching. " +
+      "Call this at the start of a session with results from th0th_recall to warm the buffer — " +
+      "subsequent th0th_search calls will boost these results automatically.",
+    apiEndpoint: "/api/v1/synapse/session/:id/prime",
+    apiMethod: "POST",
+    inputSchema: {
+      type: "object",
+      properties: {
+        id: { type: "string", description: "Session ID from th0th_synapse_session" },
+        results: {
+          type: "array",
+          description: "Array of search results to seed into the buffer (from th0th_recall or th0th_search)",
+          items: { type: "object" },
+        },
+      },
+      required: ["id", "results"],
+    },
+  },
+
+  {
+    name: "th0th_synapse_access",
+    description:
+      "Record that the agent accessed a specific file/chunk during this session. " +
+      "Increases agent-affinity score for that file in future searches — results from " +
+      "frequently-accessed files get boosted. Call after reading or editing a file.",
+    apiEndpoint: "/api/v1/synapse/session/:id/access",
+    apiMethod: "POST",
+    inputSchema: {
+      type: "object",
+      properties: {
+        id: { type: "string", description: "Session ID from th0th_synapse_session" },
+        memoryId: { type: "string", description: "Memory/chunk ID that was accessed (from search result id field)" },
+        filePath: { type: "string", description: "File path that was accessed (alternative to memoryId)" },
+      },
+      required: ["id"],
+    },
+  },
+
+  // ── Symbol snippet ───────────────────────────────────────────────────────
+
+  {
+    name: "th0th_symbol_snippet",
+    description:
+      "Get the source code snippet for a specific file and line range from an indexed project. " +
+      "Faster than th0th_read_file when you already know the exact location — returns raw content without compression.",
+    apiEndpoint: "/api/v1/symbol/snippet",
+    apiMethod: "GET",
+    inputSchema: {
+      type: "object",
+      properties: {
+        projectId: { type: "string", description: "Project ID" },
+        file: { type: "string", description: "Relative file path" },
+        lineStart: { type: "number", description: "Start line (1-indexed, default: 1)" },
+        lineEnd: { type: "number", description: "End line (default: entire file)" },
+      },
+      required: ["projectId", "file"],
+    },
+  },
+
+  // ── Memory list ──────────────────────────────────────────────────────────
+
+  {
+    name: "th0th_memory_list",
+    description:
+      "Browse stored memories for a project without a semantic query — useful when you want to " +
+      "see all decisions, patterns, or critical facts stored for a project. " +
+      "Use th0th_recall for semantic search, th0th_memory_list for browsing/auditing.",
+    apiEndpoint: "/api/v1/memory/list",
+    apiMethod: "POST",
+    inputSchema: {
+      type: "object",
+      properties: {
+        projectId: { type: "string", description: "Filter by project ID" },
+        type: { type: "string", description: "Filter by memory type: critical | decision | pattern | code | conversation" },
+        minImportance: { type: "number", description: "Minimum importance score (0-1, default: 0)" },
+        limit: { type: "number", description: "Max results to return (default: 50)", default: 50 },
+        offset: { type: "number", description: "Pagination offset (default: 0)", default: 0 },
+      },
+      required: [],
+    },
+  },
+
+  // ── Workspace reindex ────────────────────────────────────────────────────
+
+  {
+    name: "th0th_reindex",
+    description:
+      "Force a full reindex of a project workspace — re-scans all files, regenerates embeddings, " +
+      "and rebuilds the symbol graph. Use when files have changed significantly and autoReindex " +
+      "on th0th_search is too slow (autoReindex only syncs up to 50 files at a time).",
+    apiEndpoint: "/api/v1/workspace/:id/reindex",
+    apiMethod: "POST",
+    inputSchema: {
+      type: "object",
+      properties: {
+        id: { type: "string", description: "Project ID to reindex" },
+        forceReindex: {
+          type: "boolean",
+          description: "Clear existing index before reindexing (default: false — incremental)",
+          default: false,
+        },
+      },
+      required: ["id"],
     },
   },
 ];

--- a/skills/th0th-memory/SKILL.md
+++ b/skills/th0th-memory/SKILL.md
@@ -29,18 +29,26 @@ Reference these guidelines when:
 |----------|------|-----|
 | 1 | `th0th_index` | Index project before searching (returns jobId for background jobs) |
 | 2 | `th0th_index_status` | Poll background indexing job status by jobId |
-| 3 | `th0th_search` | Semantic + keyword search with filters |
-| 4 | `th0th_optimized_context` | Search + compress in one call (max token efficiency) |
-| 5 | `th0th_search_definitions` | Find symbol definitions (functions, classes, types) |
-| 6 | `th0th_get_references` | Find all usages of a symbol across the project |
-| 7 | `th0th_go_to_definition` | Jump to a symbol's definition with context |
-| 8 | `th0th_list_projects` | List all indexed projects and their status |
-| 9 | `th0th_reset_project` | Delete all indexed data for a project (vectors, symbols, memories) |
-| 10 | `th0th_remember` | Store important information in persistent memory |
-| 11 | `th0th_recall` | Retrieve memories from previous sessions |
-| 12 | `th0th_compress` | Reduce context size (70-98%) |
-| 13 | `th0th_analytics` | Usage patterns and metrics |
-| 14 | Glob/Grep/Read | Only when th0th doesn't find what you need |
+| 3 | `th0th_search` | Semantic search — use `responseMode:"enriched"` to get content + imports + parentSymbol in one call |
+| 4 | `th0th_read_file` | Read specific lines of a file with symbol metadata and imports — **use instead of Read/grep for focused reads** |
+| 5 | `th0th_optimized_context` | Search + compress in one call (max token efficiency) |
+| 6 | `th0th_search_definitions` | Find symbol definitions (functions, classes, types) |
+| 7 | `th0th_get_references` | Find all usages of a symbol across the project |
+| 8 | `th0th_go_to_definition` | Jump to a symbol's definition with code snippet |
+| 9 | `th0th_project_map` | One-shot project overview: stats, top central files (PageRank backbone), symbols by kind, files by language — use before deep search to orient yourself |
+| 10 | `th0th_list_projects` | List all indexed projects and their status |
+| 11 | `th0th_reset_project` | Delete all indexed data for a project (vectors, symbols, memories) |
+| 12 | `th0th_synapse_session` | Create/resume a Synapse cognitive session — returns sessionId to pass on every search |
+| 13 | `th0th_synapse_prime` | Seed session buffer with recalled memories before searching |
+| 14 | `th0th_synapse_access` | Record file access for affinity scoring (boosts that file in future searches) |
+| 15 | `th0th_symbol_snippet` | Get raw code snippet by file + line range (faster than read_file for known locations) |
+| 16 | `th0th_memory_list` | Browse stored memories by type/importance (auditing, not semantic search) |
+| 17 | `th0th_reindex` | Force full reindex of a project (when autoReindex is too slow) |
+| 18 | `th0th_remember` | Store important information in persistent memory |
+| 19 | `th0th_recall` | Retrieve memories from previous sessions |
+| 20 | `th0th_compress` | Reduce context size (70-98%) |
+| 21 | `th0th_analytics` | Usage patterns and metrics |
+| 22 | Glob/Grep/Read | **Last resort only** — use th0th tools above first |
 
 ## Tool Reference
 
@@ -110,8 +118,8 @@ th0th_search({
   query: "JWT authentication middleware",
   projectId: "my-project",
   maxResults: 10,
-  minScore: 0.3,
-  responseMode: "summary",   // "summary" saves ~70% tokens vs "full"
+  minScore: 0.5,             // validated default — real scores cluster 0.6-0.9
+  responseMode: "enriched",  // recommended: content + fileImports + parentSymbol
   autoReindex: false,        // set true to auto-refresh stale index
   explainScores: false,      // set true for vector/keyword/RRF breakdown
   include: ["src/**/*.ts"],
@@ -119,11 +127,37 @@ th0th_search({
 })
 ```
 
-**responseMode:**
-- `"summary"` (default) — returns preview only; saves ~70% tokens.
-- `"full"` — includes full file content; use when you need to read code.
+**responseMode — choose based on need:**
+- `"enriched"` (**recommended for dev assistance**) — full chunk content + `fileImports` (all imports of the file) + `parentSymbol` (enclosing function/class) + `chunkIndex`/`totalChunks`. Eliminates most follow-up Read/grep calls for context.
+- `"summary"` (default) — signature preview only; use when scanning many results for the right file.
+- `"full"` — full content without enrichment metadata.
 
-### 4. th0th_optimized_context
+**After a search result, navigate without grep:**
+- Need adjacent code? Use `chunkIndex` and `totalChunks` from the result — adjacent chunks have IDs `projectId:filePath:chunkIndex±1`.
+- Need the full function? Check `totalChunks` — if > 1, the function spans multiple chunks. Use `th0th_read_file` with `lineStart`/`lineEnd` from the result.
+- Need callers? Use `th0th_get_references` with `symbolName` from `parentSymbol`.
+
+### 4. th0th_read_file
+
+Read specific lines of a file with symbol metadata and imports — **use this instead of the native Read tool or Bash grep** when you have a file path and line range from a search result.
+
+```
+th0th_read_file({
+  filePath: "src/services/search.ts",
+  projectId: "my-project",
+  lineStart: 45,      // from search result lineStart (optionally subtract 5-10 for context)
+  lineEnd: 80,        // from search result lineEnd (optionally add 5-10 for context)
+  includeSymbols: true,   // returns symbol definitions/references in this range
+  includeImports: true    // returns import statements at top of file
+})
+```
+
+**Why use this instead of Read/grep:**
+- Returns `imports[]` (all file imports) and `symbols{}` (definitions + references in range)
+- Handles compression automatically for large reads
+- Respects th0th caching — repeated reads of the same range are instant
+
+### 5. th0th_optimized_context
 
 Search + compress in one call. Maximum token efficiency.
 
@@ -141,7 +175,7 @@ th0th_optimized_context({
 
 The response includes `metadata.tokensSavedBySessionCache` and `data.sessionCacheHits` so you can observe the savings.
 
-### 5. th0th_search_definitions
+### 6. th0th_search_definitions
 
 Find symbol definitions (functions, classes, variables, types, interfaces, exports) in an indexed project.
 
@@ -156,7 +190,7 @@ th0th_search_definitions({
 })
 ```
 
-### 6. th0th_get_references
+### 7. th0th_get_references
 
 Find all usages of a symbol across the project. Returns file paths, line numbers, reference kinds (`call`, `import`, `type_ref`, `extend`, `implement`), and code context.
 
@@ -169,7 +203,7 @@ th0th_get_references({
 })
 ```
 
-### 7. th0th_go_to_definition
+### 8. th0th_go_to_definition
 
 Jump to a symbol's definition. Disambiguates using calling file context.
 
@@ -181,7 +215,28 @@ th0th_go_to_definition({
 })
 ```
 
-### 8. th0th_list_projects
+### 9. th0th_project_map
+
+One-shot architectural overview of an indexed project. Use this **before diving into search** on an unfamiliar codebase — gives you the backbone in one call.
+
+Returns:
+- **Stats**: total files, chunks, symbols, last indexed
+- **Top central files**: PageRank backbone (files most depended on — start here)
+- **Symbols by kind**: count of functions, classes, interfaces, types
+- **Files by language**: distribution across extensions
+- **Recently indexed files**: what changed last
+
+```
+th0th_project_map({
+  projectId: "my-project",
+  topFiles: 20,       // top central files to show (default 20)
+  recentFiles: 10     // most recently indexed files (default 10)
+})
+```
+
+**When to use:** starting a new task in an unfamiliar project → call `th0th_project_map` first, then `th0th_search` for specifics.
+
+### 10. th0th_list_projects
 
 List all indexed projects and their current status.
 
@@ -191,7 +246,7 @@ th0th_list_projects({
 })
 ```
 
-### 9. th0th_reset_project
+### 10. th0th_reset_project
 
 Delete all indexed data for a project. Each scope is independent and defaults to `true`.
 
@@ -211,7 +266,7 @@ th0th_reset_project({
 
 **Response includes:** `vectorsDeleted`, `symbolsCleared`, `memoriesDeleted` counts.
 
-### 10. th0th_remember
+### 11. th0th_remember
 
 Store important information in persistent memory.
 
@@ -228,7 +283,7 @@ th0th_remember({
 })
 ```
 
-### 11. th0th_recall
+### 12. th0th_recall
 
 Search stored memories from previous sessions.
 
@@ -245,7 +300,7 @@ th0th_recall({
 })
 ```
 
-### 12. th0th_compress
+### 13. th0th_compress
 
 Compress context (keeps structure, removes details).
 
@@ -258,7 +313,7 @@ th0th_compress({
 })
 ```
 
-### 13. th0th_analytics
+### 14. th0th_analytics
 
 Usage patterns, cache performance, metrics.
 
@@ -279,35 +334,111 @@ th0th_analytics({
 | `semantic_dedup` | Repetitive content | 50-70% |
 | `hierarchical` | Structured docs | 60-80% |
 
-## Memory Types
+## Memory Types & Tiers
 
-| Type | Use |
-|------|-----|
-| `critical` | Critical user-defined facts |
-| `conversation` | Important conversation points |
-| `code` | Code patterns discovered |
-| `decision` | Architecture decisions |
-| `pattern` | Recurring patterns |
+| Type | Tier | Use |
+|------|------|-----|
+| `critical` | Semantic | Hard constraints, env secrets, non-negotiable rules |
+| `decision` | Semantic | Architecture decisions with rationale |
+| `pattern` | Semantic | Recurring patterns discovered through work |
+| `code` | Episodic | Code patterns found in a specific session |
+| `conversation` | Episodic | Key conversation points, resolved ambiguities |
+| *(tagged `working`)* | Working | Short-lived task state — tag `working`, low importance |
+| *(tagged `procedure`)* | Procedural | How-to steps that recur across projects |
+
+**Tier guidance:**
+- **Working**: ephemeral (current task state). Tag: `working`. Importance ≤ 0.5.
+- **Episodic**: session discoveries. Importance 0.5–0.7.
+- **Semantic**: cross-session facts that compound. Importance ≥ 0.7.
+- **Procedural**: reusable recipes. Tag: `procedure`. Importance ≥ 0.7.
+
+## Memory Importance Rubric
+
+**Never set importance by gut feel.** Use this 5-question rubric — base is 0.50:
+
+| Question | If YES → add |
+|----------|-------------|
+| 1. Would forgetting this cause a bug or wrong decision? | +0.15 |
+| 2. Affects more than one module/service? | +0.10 |
+| 3. A future agent would choose wrong without this? | +0.15 |
+| 4. Took significant effort to discover (hours, not minutes)? | +0.10 |
+| 5. Is this a hard constraint, not a preference? | +0.10 |
+
+**Named levels:** CRITICAL ≥ 0.95 · HIGH ≥ 0.80 · MEDIUM ≥ 0.70 · LOW ≥ 0.60 · SKIP < 0.60
+
+**Examples:**
+- "Auth uses short-lived JWT + refresh token (15 min TTL)" → 0.95 (CRITICAL — all 5 yes)
+- "Team prefers async/await over .then()" → 0.60 (LOW — preference, not constraint)
+- "SQLite fails on concurrent writes > 50/s" → 0.85 (HIGH — hard constraint, multi-module)
+- "Found that lazy-loading reduces TTI by 40%" → 0.70 (MEDIUM — 1+3+4)
+
+## Session Management
+
+**Always pass `sessionId` to `th0th_search`, `th0th_remember`, and `th0th_recall`.**
+
+**Name sessions by intent:**
+```
+debug-[entity]       → "debug-auth-middleware"
+feature-[entity]     → "feature-payment-flow"
+refactor-[entity]    → "refactor-search-pipeline"
+review-[entity]      → "review-pr-142"
+explore-[entity]     → "explore-onboarding-flow"
+```
+
+**Session rules:**
+- Reuse the same `sessionId` across ALL turns of a task (don't generate a new one each call)
+- At task END: call `th0th_remember` with decisions, patterns, and unresolved issues found
+- At task START: call `th0th_recall` with the same topic before doing any search
 
 ## Decision Flow
 
 ```
 Need to find code?
-  → th0th_search with responseMode:"summary" (first)
-  → Glob/Grep/Read (fallback only)
+  → th0th_search with responseMode:"enriched" (preferred — returns content + imports + parentSymbol)
+  → responseMode:"summary" if scanning many results to locate the right file
+  → Glob/Grep/Read — LAST RESORT ONLY, after th0th_search returned nothing useful
+
+Got a search result and need more context?
+  → result already has fileImports (imports of the file) and parentSymbol (enclosing function/class)
+  → Need surrounding lines? → th0th_read_file(filePath, lineStart-10, lineEnd+10)  [NOT Read/grep]
+  → Need callers of this function? → th0th_get_references(symbolName=parentSymbol)
+  → Function spans multiple chunks? → th0th_read_file with full lineStart..lineEnd range
+  → NEVER grep just to see surrounding lines or imports — enriched mode already has them
 
 Need to navigate symbols?
-  → th0th_go_to_definition (jump to definition)
-  → th0th_get_references (find all usages)
-  → th0th_search_definitions (list matching symbols)
+  → th0th_go_to_definition (jump to definition with code snippet)
+  → th0th_get_references (find all usages — replaces grep for symbol search)
+  → th0th_search_definitions (list all matching symbols by name/kind)
+
+Need to read a specific file section?
+  → th0th_read_file(filePath, lineStart, lineEnd) — returns content + symbols + imports
+  → Do NOT use Read/grep when you have file + line numbers from a search result
+
+Starting work on an unfamiliar project?
+  → th0th_project_map (one-shot overview: backbone files, symbol counts, languages)
+  → th0th_recall (check memories from prior sessions)
+  → th0th_search with responseMode:"enriched" (dive into specifics)
 
 Need to understand architecture?
-  → th0th_recall (check memories first)
-  → th0th_search (explore code)
-  → th0th_search_definitions (enumerate public API)
+  → th0th_project_map (central files by PageRank = dependency backbone)
+  → th0th_search_definitions (enumerate public API by kind)
+  → th0th_recall (check stored decisions)
+
+Debugging an issue?
+  → th0th_recall("debug [component]") FIRST — check if this was investigated before
+  → Only pursue hypotheses NOT already ruled out in prior sessions
+  → After resolving: th0th_remember with what the root cause was AND what was ruled out
+  → NEVER re-investigate a hypothesis without recalling prior attempts first
 
 Found important pattern/decision?
-  → th0th_remember (store for future sessions)
+  → Score importance with the 5-question rubric above (never pick a float by feel)
+  → th0th_remember with sessionId, type="decision"|"pattern", calibrated importance
+  → Tag constraints as `critical`, preferences as `pattern`
+
+Task complete? — Evidence gate (don't just say "done"):
+  → Tests pass / build succeeds → show output
+  → If code changed: verify the changed artifact exists and compiles
+  → th0th_remember any decisions/blockers/patterns discovered during the task
 
 Context too large?
   → th0th_compress (reduce tokens)
@@ -326,7 +457,46 @@ Indexing taking long?
 Need a clean slate before reindexing?
   → th0th_reset_project (wipe vectors + symbols + memories)
   → th0th_index (reindex from scratch)
+
+Starting a multi-step task (debugging, code review, refactor)?
+  → th0th_synapse_session(taskContext="<one sentence>", workspaceId="<projectId>") → get sessionId
+  → th0th_recall("<topic>") → th0th_synapse_prime(id=sessionId, results=[...recalled])
+  → Pass sessionId as synapseSessionId on every th0th_search call
+  → After reading/editing a file: th0th_synapse_access(id=sessionId, filePath="...")
+  → On task end: th0th_remember(sessionId=sessionId, ...) to persist discoveries
+
+Want to audit stored knowledge?
+  → th0th_memory_list(projectId="...", type="decision") — browse all decisions
+  → th0th_memory_list(minImportance=0.8) — browse only critical/high memories
+
+Index is stale after large refactor?
+  → th0th_reindex(id="<projectId>") — full reindex (use when autoReindex misses > 50 files)
 ```
+
+## Companion Skill: synapse-usage
+
+For multi-step tasks where the same files and concepts will reappear across
+several searches, layer the **synapse-usage** skill on top of these tools.
+Synapse is th0th's cognitive modulation layer — it does not replace
+`th0th_search` or `th0th_optimized_context`; it sits between RRF and the
+caller, modulating which results survive and in what order.
+
+**When to combine:** any task with ≥2 related searches in the same
+conversation. Synapse opens a session, primes a working-memory buffer with
+known-relevant memories (from `th0th_recall`), and applies per-query the
+attention, chain, diversity, temporal, and confidence-gate filters.
+
+**Integration point with the tools above:**
+
+| th0th tool | How synapse-usage extends it |
+|------------|------------------------------|
+| `th0th_search` / `th0th_optimized_context` | Pass `synapseSessionId` — server runs the full Synapse pipeline automatically |
+| `th0th_recall` | Use returned memories to `prime` the Synapse buffer at session start |
+| `th0th_go_to_definition`, `th0th_get_references` | Call `/session/:id/prefetch` with the resolved `filePath` to warm the buffer before the next search |
+| `th0th_remember` (decision) | Reference the new memory id in `/session/:id/access` so future agent-affinity scoring favors it |
+
+See `skills/synapse-usage/SKILL.md` for the full lifecycle, REST endpoints,
+decision flow, and pitfalls.
 
 ## Installation
 


### PR DESCRIPTION
## Summary

Expõe endpoints existentes que o MCP client nunca registrou, e atualiza o SKILL.md para guiar o AI a usar as ferramentas certas.

### 6 novos tools MCP (14 → 21)

| Tool | Serve para |
|---|---|
| `th0th_read_file` | Ler arquivo com imports[] + símbolos — substitui `Read`/grep quando você tem filePath+lineNumbers de um resultado de busca |
| `th0th_project_map` | Overview do projeto em uma chamada (PageRank backbone, contagem de símbolos, distribuição de linguagens) |
| `th0th_synapse_session` | Criar/retomar sessão cognitiva — retorna `sessionId` para passar como `synapseSessionId` em toda busca |
| `th0th_synapse_prime` | Semear buffer de memória de trabalho com resultados de `th0th_recall` antes de buscar |
| `th0th_synapse_access` | Registrar acesso a arquivo para scoring de afinidade (boost em buscas futuras) |
| `th0th_symbol_snippet` | Obter snippet de código por file+lineRange — mais rápido que `read_file` para localizações conhecidas |
| `th0th_memory_list` | Navegar memórias por tipo/importância sem query semântica (auditoria) |
| `th0th_reindex` | Forçar reindex completo quando `autoReindex` (max 50 arquivos) é insuficiente |

### SKILL.md v3 — de referência de tools para sistema operacional de memória

**Novo:**
- **Rubrica de importância** — 5 perguntas determinísticas (base 0.5 + critérios objetivos) em vez de float subjetivo
- **Memory tiers** — Working/Episodic/Semantic/Procedural com guidance de importância
- **Session management** — nomenclatura por intent (`debug-auth`, `feature-payment`), regras de reuso e recall-first
- **Padrão de debug** — `th0th_recall` de tentativas anteriores OBRIGATÓRIO antes de investigar (não repetir hipóteses descartadas)
- **Evidence gate** — completar = evidência concreta (output de teste/build), não self-declared
- **`th0th_read_file`** adicionado como tool prioritária (estava ausente; AI usava `Read`/grep)
- **`responseMode="enriched"`** documentado como default recomendado
- **`th0th_project_map`** + lifecycle do Synapse integrado no Decision Flow

## Test plan

- [ ] MCP client carrega sem erros TypeScript
- [ ] `th0th_read_file` retorna `imports[]` e `symbols{}` para um arquivo indexado
- [ ] `th0th_project_map` retorna `topFiles`, contagem de símbolos, distribuição de linguagens
- [ ] `th0th_synapse_session` cria sessão e retorna `sessionId`
- [ ] `th0th_memory_list` lista memórias por `type="decision"` sem query semântica

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added tools for file reading with compression, session management, memory browsing with filters, symbol retrieval, and workspace reindexing
  * Introduced "enriched" search response mode providing full content plus enhanced metadata

* **Improvements**
  * Enhanced search results with better preview extraction and symbol information
  * Improved ignore patterns for monorepo and subdirectory support
  * Better file import tracking and context preservation in search indexing

* **Documentation**
  * Expanded memory management workflow and tool usage guidance
<!-- end of auto-generated comment: release notes by coderabbit.ai -->